### PR TITLE
Update links from lib.umich.edu to www.lib.umich.edu

### DIFF
--- a/src/modules/core/components/Header/index.js
+++ b/src/modules/core/components/Header/index.js
@@ -16,7 +16,7 @@ class Header extends React.Component {
                     <img src={umichBlockM} alt="Go to the University of Michigan Library homepage" />
                   </a>
                 </li>
-                <li className="logo-library"><a href="http://lib.umich.edu">Library</a></li>
+                <li className="logo-library"><a href="https://www.lib.umich.edu">Library</a></li>
                 <li className="logo-search">
                   <span>
                     <Link to="/">Search</Link>

--- a/src/modules/getthis/components/GetThisForm/index.js
+++ b/src/modules/getthis/components/GetThisForm/index.js
@@ -132,7 +132,7 @@ class GetThisForm extends React.Component {
               <li>When it is available, we'll hold it for you for 7 days.</li>
             </ul>
 
-            <a href="https://lib.umich.edu/my-account/holds-recalls" className="underline">View all your holds</a>
+            <a href="https://www.lib.umich.edu/my-account/holds-recalls" className="underline">View all your holds</a>
           </article>
         )
       } else {


### PR DESCRIPTION
We have a dispreference for using `lib.umich.edu`. It's for technical reasons, relating to how dns works. 
`lib.umich.edu` can't work with our multi-site redundancy, but `www.lib.umich.edu` can.