### PR TITLE
Update access type.

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -434,7 +434,7 @@ const config = {
       full: {
         standard: [
           'type',
-          'access_icon',
+          'smfield_access_type',
           'new',
           'trial',
           'permalink',
@@ -654,12 +654,12 @@ const config = {
         open: true,
       },
       {
-        uid: 'type',
+        uid: 'smfield_access_type',
         open: true,
       },
       {
-        uid: 'access',
-        open: false,
+        uid: 'type',
+        open: true,
       },
     ],
     'journals': [


### PR DESCRIPTION
Some filter values don't apply cleanly.  The ones with parens and/or plus signs.  May be an encoding issue along the way.

I also did want to map to the uid `access_type`, but that was afflicted by the other filtering bug.  Maybe when the other bug is fixed.