### PR TITLE
Add specialists from the active datastore only

### DIFF
--- a/src/modules/pride/setup.js
+++ b/src/modules/pride/setup.js
@@ -94,7 +94,9 @@ const handleSearchData = (data, datastoreUid) => {
     datastoreUid: datastoreUid
   }
 
-  if (data.specialists) {
+  const activeDatastore = store.getState().datastores.active;
+
+  if ((activeDatastore === 'everything' || activeDatastore === datastoreUid) && data.specialists) {
     store.dispatch(addSpecialists(data.specialists))
   }
 


### PR DESCRIPTION
This improved the situation we experienced where subject specialists from inactive results overwrite specialists from the active results.  This is especially prominent for searchers where the academic discipline filter is applied.