### PR TITLE
Add HotJar data attribute to search inputs.

### DIFF
--- a/src/modules/advanced/components/FieldInput/index.js
+++ b/src/modules/advanced/components/FieldInput/index.js
@@ -1,19 +1,13 @@
-import React from 'react'
-import {
-  Icon,
-  MEDIA_QUERIES,
-  TextInput
-} from '@umich-lib/core'
-import {
-  MultipleChoice
-} from '../../../core'
-import styled from '@emotion/styled'
+import React from "react";
+import { Icon, MEDIA_QUERIES, TextInput } from "@umich-lib/core";
+import { MultipleChoice } from "../../../core";
+import styled from "@emotion/styled";
 
-const StyledFieldSet = styled('fieldset')({
+const StyledFieldSet = styled("fieldset")({
   [MEDIA_QUERIES.LARGESCREEN]: {
-    textAlign: 'center'
+    textAlign: "center"
   }
-})
+});
 
 const Dropdown = ({
   labelText,
@@ -24,40 +18,47 @@ const Dropdown = ({
   multiple
 }) => (
   <select
-    aria-label={labelText ? labelText : 'dropdown'}
+    aria-label={labelText ? labelText : "dropdown"}
     className="dropdown advanced-field-select"
     value={selectedOption}
     multiple={multiple ? multiple : false}
-    onChange={(event) => handleOnFieldChange({
-      fieldedSearchIndex,
-      selectedFieldUid: event.target.value,
-    })}
+    onChange={event =>
+      handleOnFieldChange({
+        fieldedSearchIndex,
+        selectedFieldUid: event.target.value
+      })
+    }
   >
-    {options.map((option, index) =>
-      <option value={option.uid} key={index}>{option.name}</option>
-    )}
+    {options.map((option, index) => (
+      <option value={option.uid} key={index}>
+        {option.name}
+      </option>
+    ))}
   </select>
-)
+);
 
 const FieldInput = ({
   fieldedSearchIndex,
   fieldedSearch,
   fields,
   handleFieldedSearchChange,
-  handleRemoveFieldedSearch,
+  handleRemoveFieldedSearch
 }) => (
   <StyledFieldSet className="y-spacing">
     <legend className="offpage">Search field {fieldedSearchIndex + 1}</legend>
     {fieldedSearchIndex === 0 ? null : (
       <MultipleChoice
         name={`search-field-${fieldedSearchIndex}-booleans`}
-        heading={`Boolean operator for field ${fieldedSearchIndex} and field ${fieldedSearchIndex + 1}`}
-        options={['AND', 'OR', 'NOT']}
+        heading={`Boolean operator for field ${fieldedSearchIndex} and field ${fieldedSearchIndex +
+          1}`}
+        options={["AND", "OR", "NOT"]}
         selectedIndex={fieldedSearch.booleanType}
-        onMultipleChoiceChange={({ index }) => handleFieldedSearchChange({
-          fieldedSearchIndex,
-          booleanType: index
-        })}
+        onMultipleChoiceChange={({ index }) =>
+          handleFieldedSearchChange({
+            fieldedSearchIndex,
+            booleanType: index
+          })
+        }
       />
     )}
     <div className="advanced-input-container">
@@ -75,22 +76,29 @@ const FieldInput = ({
           value={fieldedSearch.query}
           labelText={`Search Term ${fieldedSearchIndex + 1}`}
           hideLabel
-          onChange={(event) => handleFieldedSearchChange({
-            fieldedSearchIndex,
-            query: event.target.value
-          })}
+          data-hj-whitelist
+          onChange={event =>
+            handleFieldedSearchChange({
+              fieldedSearchIndex,
+              query: event.target.value
+            })
+          }
         />
         {fieldedSearchIndex > 0 ? (
           <button
             className="advanced-input-remove-button"
             type="button"
-            onClick={handleRemoveFieldedSearch}>
-              <Icon icon="close" size={24} /><span className="offpage">Remove Field {fieldedSearchIndex + 1}</span>
+            onClick={handleRemoveFieldedSearch}
+          >
+            <Icon icon="close" size={24} />
+            <span className="offpage">
+              Remove Field {fieldedSearchIndex + 1}
+            </span>
           </button>
         ) : null}
       </div>
     </div>
   </StyledFieldSet>
-)
+);
 
-export default FieldInput
+export default FieldInput;

--- a/src/modules/advanced/components/FieldInput/index.js
+++ b/src/modules/advanced/components/FieldInput/index.js
@@ -5,8 +5,8 @@ import styled from "@emotion/styled";
 
 const StyledFieldSet = styled("fieldset")({
   [MEDIA_QUERIES.LARGESCREEN]: {
-    textAlign: "center"
-  }
+    textAlign: "center",
+  },
 });
 
 const Dropdown = ({
@@ -15,17 +15,17 @@ const Dropdown = ({
   options,
   selectedOption,
   handleOnFieldChange,
-  multiple
+  multiple,
 }) => (
   <select
     aria-label={labelText ? labelText : "dropdown"}
     className="dropdown advanced-field-select"
     value={selectedOption}
     multiple={multiple ? multiple : false}
-    onChange={event =>
+    onChange={(event) =>
       handleOnFieldChange({
         fieldedSearchIndex,
-        selectedFieldUid: event.target.value
+        selectedFieldUid: event.target.value,
       })
     }
   >
@@ -42,21 +42,22 @@ const FieldInput = ({
   fieldedSearch,
   fields,
   handleFieldedSearchChange,
-  handleRemoveFieldedSearch
+  handleRemoveFieldedSearch,
 }) => (
   <StyledFieldSet className="y-spacing">
     <legend className="offpage">Search field {fieldedSearchIndex + 1}</legend>
     {fieldedSearchIndex === 0 ? null : (
       <MultipleChoice
         name={`search-field-${fieldedSearchIndex}-booleans`}
-        heading={`Boolean operator for field ${fieldedSearchIndex} and field ${fieldedSearchIndex +
-          1}`}
+        heading={`Boolean operator for field ${fieldedSearchIndex} and field ${
+          fieldedSearchIndex + 1
+        }`}
         options={["AND", "OR", "NOT"]}
         selectedIndex={fieldedSearch.booleanType}
         onMultipleChoiceChange={({ index }) =>
           handleFieldedSearchChange({
             fieldedSearchIndex,
-            booleanType: index
+            booleanType: index,
           })
         }
       />
@@ -76,11 +77,11 @@ const FieldInput = ({
           value={fieldedSearch.query}
           labelText={`Search Term ${fieldedSearchIndex + 1}`}
           hideLabel
-          data-hj-whitelist
-          onChange={event =>
+          data-hj-allow
+          onChange={(event) =>
             handleFieldedSearchChange({
               fieldedSearchIndex,
-              query: event.target.value
+              query: event.target.value,
             })
           }
         />

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -1,21 +1,13 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
-import qs from 'qs'
-import {
-  withRouter,
-  Link,
-} from 'react-router-dom'
-import _ from 'underscore'
+import React from "react";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import qs from "qs";
+import { withRouter, Link } from "react-router-dom";
+import _ from "underscore";
 
-import {
-  setSearchQueryInput,
-  searching
-} from '../../actions'
-import {
-  Icon
-} from '../../../core';
-import ReactGA from 'react-ga'
+import { setSearchQueryInput, searching } from "../../actions";
+import { Icon } from "../../../core";
+import ReactGA from "react-ga";
 
 class SearchBox extends React.Component {
   constructor(props) {
@@ -27,16 +19,16 @@ class SearchBox extends React.Component {
   }
 
   handleChange(query) {
-    this.props.setSearchQueryInput(query)
+    this.props.setSearchQueryInput(query);
   }
 
   onBackButtonEvent(e) {
-    const { query } = this.props
-    this.handleChange(query)
+    const { query } = this.props;
+    this.handleChange(query);
   }
 
   componentDidMount() {
-    window.onpopstate = this.onBackButtonEvent
+    window.onpopstate = this.onBackButtonEvent;
   }
 
   handleSubmit(event) {
@@ -49,43 +41,58 @@ class SearchBox extends React.Component {
       institution,
       sort,
       activeDatastore
-    } = this.props
+    } = this.props;
 
     ReactGA.event({
-      action: 'Click',
-      category: 'Search Button',
+      action: "Click",
+      category: "Search Button",
       label: `Search ${activeDatastore.name}`
-    })
+    });
 
-    const library = activeDatastore.uid === 'mirlyn' ? institution.active : undefined
+    const library =
+      activeDatastore.uid === "mirlyn" ? institution.active : undefined;
 
     // Query is not empty
     if (queryInput.length > 0) {
-      const queryString = qs.stringify({
-        query: queryInput,
-        filter: activeFilters,
-        library,
-        sort
-      }, {
-        arrayFormat: 'repeat',
-        encodeValuesOnly: true,
-        allowDots: true,
-        format : 'RFC1738'
-      })
+      const queryString = qs.stringify(
+        {
+          query: queryInput,
+          filter: activeFilters,
+          library,
+          sort
+        },
+        {
+          arrayFormat: "repeat",
+          encodeValuesOnly: true,
+          allowDots: true,
+          format: "RFC1738"
+        }
+      );
 
-      const url = `/${match.params.datastoreSlug}?${queryString}`
+      const url = `/${match.params.datastoreSlug}?${queryString}`;
 
-      history.push(url)
+      history.push(url);
     }
   }
 
   render() {
-    const { match, location, queryInput, isAdvanced, activeDatastore } = this.props
+    const {
+      match,
+      location,
+      queryInput,
+      isAdvanced,
+      activeDatastore
+    } = this.props;
 
     return (
       <div className="search-box-container-full">
         <div className="search-box-container">
-          <form className="search-box-form" onSubmit={this.handleSubmit} role="search" id="search-box">
+          <form
+            className="search-box-form"
+            onSubmit={this.handleSubmit}
+            role="search"
+            id="search-box"
+          >
             <div className="search-box">
               <input
                 id="search-query"
@@ -94,14 +101,21 @@ class SearchBox extends React.Component {
                 aria-label="search text"
                 value={queryInput}
                 spellCheck="false"
+                data-hj-whitelist
                 onChange={event => this.handleChange(event.target.value)}
               />
-              <button className="button search-box-button" type="submit"><Icon name="search"/><span className="search-box-button-text">Search</span></button>
+              <button className="button search-box-button" type="submit">
+                <Icon name="search" />
+                <span className="search-box-button-text">Search</span>
+              </button>
             </div>
 
             {isAdvanced && (
               <div className="search-box-advanced">
-                <Link to={`/${match.params.datastoreSlug}/advanced${location.search}`} className="search-box-advanced-link">
+                <Link
+                  to={`/${match.params.datastoreSlug}/advanced${location.search}`}
+                  className="search-box-advanced-link"
+                >
                   <span className="offpage">{activeDatastore.name}</span>
                   <span>Advanced</span>
                   <span className="offpage">Search</span>
@@ -111,7 +125,7 @@ class SearchBox extends React.Component {
           </form>
         </div>
       </div>
-    )
+    );
   }
 }
 
@@ -121,7 +135,9 @@ function mapStateToProps(state) {
     query: state.search.query,
     queryInput: state.search.queryInput,
     activeFilters: state.filters.active[state.datastores.active],
-    activeDatastore: _.findWhere(state.datastores.datastores, { uid: state.datastores.active }),
+    activeDatastore: _.findWhere(state.datastores.datastores, {
+      uid: state.datastores.active
+    }),
     location: state.router.location,
     isAdvanced: state.advanced[state.datastores.active] ? true : false,
     institution: state.institution,
@@ -131,10 +147,13 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({
-    setSearchQueryInput,
-    searching
-  }, dispatch)
+  return bindActionCreators(
+    {
+      setSearchQueryInput,
+      searching
+    },
+    dispatch
+  );
 }
 
 export default withRouter(

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -40,13 +40,13 @@ class SearchBox extends React.Component {
       activeFilters,
       institution,
       sort,
-      activeDatastore
+      activeDatastore,
     } = this.props;
 
     ReactGA.event({
       action: "Click",
       category: "Search Button",
-      label: `Search ${activeDatastore.name}`
+      label: `Search ${activeDatastore.name}`,
     });
 
     const library =
@@ -59,13 +59,13 @@ class SearchBox extends React.Component {
           query: queryInput,
           filter: activeFilters,
           library,
-          sort
+          sort,
         },
         {
           arrayFormat: "repeat",
           encodeValuesOnly: true,
           allowDots: true,
-          format: "RFC1738"
+          format: "RFC1738",
         }
       );
 
@@ -81,7 +81,7 @@ class SearchBox extends React.Component {
       location,
       queryInput,
       isAdvanced,
-      activeDatastore
+      activeDatastore,
     } = this.props;
 
     return (
@@ -101,8 +101,8 @@ class SearchBox extends React.Component {
                 aria-label="search text"
                 value={queryInput}
                 spellCheck="false"
-                data-hj-whitelist
-                onChange={event => this.handleChange(event.target.value)}
+                data-hj-allow
+                onChange={(event) => this.handleChange(event.target.value)}
               />
               <button className="button search-box-button" type="submit">
                 <Icon name="search" />
@@ -136,13 +136,13 @@ function mapStateToProps(state) {
     queryInput: state.search.queryInput,
     activeFilters: state.filters.active[state.datastores.active],
     activeDatastore: _.findWhere(state.datastores.datastores, {
-      uid: state.datastores.active
+      uid: state.datastores.active,
     }),
     location: state.router.location,
     isAdvanced: state.advanced[state.datastores.active] ? true : false,
     institution: state.institution,
     datastores: state.datastores,
-    sort: state.search.sort[state.datastores.active]
+    sort: state.search.sort[state.datastores.active],
   };
 }
 
@@ -150,7 +150,7 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators(
     {
       setSearchQueryInput,
-      searching
+      searching,
     },
     dispatch
   );


### PR DESCRIPTION
Robyn requested that HotJar whitelist search input elements so that they can be recorded. This PR adds the `data-hj-whitelist` data attribute to the primary search box and the advanced search boxes.

Related HotJar docs: https://help.hotjar.com/hc/en-us/articles/115015563287-How-to-Whitelist-Elements-and-Keystrokes