### PR TITLE
Have `RecordFullFormats` use `record.formats`.

### DIFF
--- a/src/modules/getthis/components/GetThisRecord/index.js
+++ b/src/modules/getthis/components/GetThisRecord/index.js
@@ -75,7 +75,7 @@ function GetThisHolding({ record, barcode }) {
 
 class GetThisRecord extends React.Component {
   render() {
-    const { record, datastoreUid, barcode } = this.props;
+    const { record, barcode } = this.props;
 
     if (!record) {
       return <FullRecordPlaceholder />;
@@ -83,11 +83,7 @@ class GetThisRecord extends React.Component {
 
     return (
       <div className="full-record-container u-margin-bottom-1">
-        <RecordFullFormats
-          icons={record.icons}
-          fields={record.fields}
-          datastoreUid={datastoreUid}
-        />
+        <RecordFullFormats formats={record.formats} />
         <div className="record-container">
           <h1 className="full-record-title u-margin-bottom-none">
             {[].concat(record.names).map((title, index) => (

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -158,11 +158,7 @@ class FullRecord extends React.Component {
         <FullRecordBreadcrumbs datastore={datastore} />
         <GoToList list={list} datastore={datastore} />
         <div className={recordClassName}>
-          <RecordFullFormats
-            icons={record.icons}
-            fields={record.fields}
-            datastoreUid={datastoreUid}
-          />
+          <RecordFullFormats formats={record.formats} />
           <div className="record-container">
             <div className="full-record-title-and-actions-container">
               <h1 className="full-record-title">

--- a/src/modules/records/components/RecordFullFormats/index.js
+++ b/src/modules/records/components/RecordFullFormats/index.js
@@ -1,24 +1,19 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import React from "react";
 
 import { Icon } from "@umich-lib/core";
-import { getRecordFormats } from "../../utilities";
 import { SPACING } from "../../../reusable/umich-lib-core-temp";
 
-export default function RecordFullFormats({ icons, fields, datastoreUid }) {
-  const formats = getRecordFormats({
-    fields,
-    datastoreUid,
-  });
+export default function RecordFullFormats({ formats }) {
 
   return (
     <div className="full-record-header">
-      {formats.map((value, index) => {
+      
+      {(formats || []).map((format, index) => {
         return (
           <span className="full-record-format" key={index}>
-            <RecordFormatIcon icons={icons} value={value} />
-            {value}
+            <RecordFormatIcon icon={format.icon} />
+            {format.text}
           </span>
         );
       })}
@@ -26,17 +21,12 @@ export default function RecordFullFormats({ icons, fields, datastoreUid }) {
   );
 }
 
-function RecordFormatIcon({ value, icons }) {
-  if (!icons) {
-    return null;
-  }
-
-  const icon = icons.find((i) => i.text === value);
+function RecordFormatIcon({ icon }) {
 
   if (icon) {
     return (
       <Icon
-        icon={icon.icon}
+        icon={icon}
         css={{
           marginRight: SPACING["2XS"],
         }}

--- a/src/modules/records/utilities/index.js
+++ b/src/modules/records/utilities/index.js
@@ -139,15 +139,6 @@ const getShowAllText = ({ holdingUid, datastoreUid }) => {
   return undefined;
 };
 
-const getRecordFormats = ({ fields }) => {
-  const format = getField(fields, "format");
-
-  if (format) {
-    return getFieldValue(format);
-  }
-  return [];
-};
-
 export {
   getField,
   getFieldValue,
@@ -156,5 +147,4 @@ export {
   isFullRecordType,
   getShowAllText,
   getFullRecordDisplayFields,
-  getRecordFormats,
 };


### PR DESCRIPTION
Clean up unused variables and code now that formats are a top-level attribute on records.