### PR TITLE
SEARCH-1155 Add redirect for librarywebsite to guides

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,13 @@ class App extends React.Component {
               <ScrollToTop>
                 <Main>
                   <ConnectedSwitch>
+                    <Route path="/librarywebsite" render={({location}) => (
+                      <Redirect 
+                      to={{
+                          ...location,
+                          pathname: location.pathname.replace(/librarywebsite/, 'guidesandmore'),
+                      }} />
+                    )} />
                     <Route path="/technical-overview" exact component={TechnicalOverview}/>
                     <Route path="/accessibility" exact component={AccessibilityPage}/>
                     <Route path="/" exact render={() => (


### PR DESCRIPTION
As requested in SEARCH-1155, urls with /librarywebsite will redirect to /guidesandmore and carry over the search parameters. 