### PR TITLE
SEARCH-1169 Add hotjar allow data attribute to search inputs

### DIFF
--- a/src/modules/advanced/components/FieldInput/index.js
+++ b/src/modules/advanced/components/FieldInput/index.js
@@ -1,19 +1,13 @@
-import React from 'react'
-import {
-  Icon,
-  MEDIA_QUERIES,
-  TextInput
-} from '@umich-lib/core'
-import {
-  MultipleChoice
-} from '../../../core'
-import styled from '@emotion/styled'
+import React from "react";
+import { Icon, MEDIA_QUERIES, TextInput } from "@umich-lib/core";
+import { MultipleChoice } from "../../../core";
+import styled from "@emotion/styled";
 
-const StyledFieldSet = styled('fieldset')({
+const StyledFieldSet = styled("fieldset")({
   [MEDIA_QUERIES.LARGESCREEN]: {
-    textAlign: 'center'
-  }
-})
+    textAlign: "center",
+  },
+});
 
 const Dropdown = ({
   labelText,
@@ -21,23 +15,27 @@ const Dropdown = ({
   options,
   selectedOption,
   handleOnFieldChange,
-  multiple
+  multiple,
 }) => (
   <select
-    aria-label={labelText ? labelText : 'dropdown'}
+    aria-label={labelText ? labelText : "dropdown"}
     className="dropdown advanced-field-select"
     value={selectedOption}
     multiple={multiple ? multiple : false}
-    onChange={(event) => handleOnFieldChange({
-      fieldedSearchIndex,
-      selectedFieldUid: event.target.value,
-    })}
+    onChange={(event) =>
+      handleOnFieldChange({
+        fieldedSearchIndex,
+        selectedFieldUid: event.target.value,
+      })
+    }
   >
-    {options.map((option, index) =>
-      <option value={option.uid} key={index}>{option.name}</option>
-    )}
+    {options.map((option, index) => (
+      <option value={option.uid} key={index}>
+        {option.name}
+      </option>
+    ))}
   </select>
-)
+);
 
 const FieldInput = ({
   fieldedSearchIndex,
@@ -51,13 +49,17 @@ const FieldInput = ({
     {fieldedSearchIndex === 0 ? null : (
       <MultipleChoice
         name={`search-field-${fieldedSearchIndex}-booleans`}
-        heading={`Boolean operator for field ${fieldedSearchIndex} and field ${fieldedSearchIndex + 1}`}
-        options={['AND', 'OR', 'NOT']}
+        heading={`Boolean operator for field ${fieldedSearchIndex} and field ${
+          fieldedSearchIndex + 1
+        }`}
+        options={["AND", "OR", "NOT"]}
         selectedIndex={fieldedSearch.booleanType}
-        onMultipleChoiceChange={({ index }) => handleFieldedSearchChange({
-          fieldedSearchIndex,
-          booleanType: index
-        })}
+        onMultipleChoiceChange={({ index }) =>
+          handleFieldedSearchChange({
+            fieldedSearchIndex,
+            booleanType: index,
+          })
+        }
       />
     )}
     <div className="advanced-input-container">
@@ -75,22 +77,29 @@ const FieldInput = ({
           value={fieldedSearch.query}
           labelText={`Search Term ${fieldedSearchIndex + 1}`}
           hideLabel
-          onChange={(event) => handleFieldedSearchChange({
-            fieldedSearchIndex,
-            query: event.target.value
-          })}
+          data-hj-allow
+          onChange={(event) =>
+            handleFieldedSearchChange({
+              fieldedSearchIndex,
+              query: event.target.value,
+            })
+          }
         />
         {fieldedSearchIndex > 0 ? (
           <button
             className="advanced-input-remove-button"
             type="button"
-            onClick={handleRemoveFieldedSearch}>
-              <Icon icon="close" size={24} /><span className="offpage">Remove Field {fieldedSearchIndex + 1}</span>
+            onClick={handleRemoveFieldedSearch}
+          >
+            <Icon icon="close" size={24} />
+            <span className="offpage">
+              Remove Field {fieldedSearchIndex + 1}
+            </span>
           </button>
         ) : null}
       </div>
     </div>
   </StyledFieldSet>
-)
+);
 
-export default FieldInput
+export default FieldInput;

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -1,21 +1,13 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
-import qs from 'qs'
-import {
-  withRouter,
-  Link,
-} from 'react-router-dom'
-import _ from 'underscore'
+import React from "react";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import qs from "qs";
+import { withRouter, Link } from "react-router-dom";
+import _ from "underscore";
 
-import {
-  setSearchQueryInput,
-  searching
-} from '../../actions'
-import {
-  Icon
-} from '../../../core';
-import ReactGA from 'react-ga'
+import { setSearchQueryInput, searching } from "../../actions";
+import { Icon } from "../../../core";
+import ReactGA from "react-ga";
 
 class SearchBox extends React.Component {
   constructor(props) {
@@ -27,16 +19,16 @@ class SearchBox extends React.Component {
   }
 
   handleChange(query) {
-    this.props.setSearchQueryInput(query)
+    this.props.setSearchQueryInput(query);
   }
 
   onBackButtonEvent(e) {
-    const { query } = this.props
-    this.handleChange(query)
+    const { query } = this.props;
+    this.handleChange(query);
   }
 
   componentDidMount() {
-    window.onpopstate = this.onBackButtonEvent
+    window.onpopstate = this.onBackButtonEvent;
   }
 
   handleSubmit(event) {
@@ -48,44 +40,59 @@ class SearchBox extends React.Component {
       activeFilters,
       institution,
       sort,
-      activeDatastore
-    } = this.props
+      activeDatastore,
+    } = this.props;
 
     ReactGA.event({
-      action: 'Click',
-      category: 'Search Button',
-      label: `Search ${activeDatastore.name}`
-    })
+      action: "Click",
+      category: "Search Button",
+      label: `Search ${activeDatastore.name}`,
+    });
 
-    const library = activeDatastore.uid === 'mirlyn' ? institution.active : undefined
+    const library =
+      activeDatastore.uid === "mirlyn" ? institution.active : undefined;
 
     // Query is not empty
     if (queryInput.length > 0) {
-      const queryString = qs.stringify({
-        query: queryInput,
-        filter: activeFilters,
-        library,
-        sort
-      }, {
-        arrayFormat: 'repeat',
-        encodeValuesOnly: true,
-        allowDots: true,
-        format : 'RFC1738'
-      })
+      const queryString = qs.stringify(
+        {
+          query: queryInput,
+          filter: activeFilters,
+          library,
+          sort,
+        },
+        {
+          arrayFormat: "repeat",
+          encodeValuesOnly: true,
+          allowDots: true,
+          format: "RFC1738",
+        }
+      );
 
-      const url = `/${match.params.datastoreSlug}?${queryString}`
+      const url = `/${match.params.datastoreSlug}?${queryString}`;
 
-      history.push(url)
+      history.push(url);
     }
   }
 
   render() {
-    const { match, location, queryInput, isAdvanced, activeDatastore } = this.props
+    const {
+      match,
+      location,
+      queryInput,
+      isAdvanced,
+      activeDatastore,
+    } = this.props;
 
     return (
       <div className="search-box-container-full">
         <div className="search-box-container">
-          <form className="search-box-form" onSubmit={this.handleSubmit} role="search" id="search-box">
+          <form
+            className="search-box-form"
+            onSubmit={this.handleSubmit}
+            role="search"
+            id="search-box"
+          >
             <div className="search-box">
               <input
                 id="search-query"
@@ -94,14 +101,21 @@ class SearchBox extends React.Component {
                 aria-label="search text"
                 value={queryInput}
                 spellCheck="false"
-                onChange={event => this.handleChange(event.target.value)}
+                data-hj-allow
+                onChange={(event) => this.handleChange(event.target.value)}
               />
-              <button className="button search-box-button" type="submit"><Icon name="search"/><span className="search-box-button-text">Search</span></button>
+              <button className="button search-box-button" type="submit">
+                <Icon name="search" />
+                <span className="search-box-button-text">Search</span>
+              </button>
             </div>
 
             {isAdvanced && (
               <div className="search-box-advanced">
-                <Link to={`/${match.params.datastoreSlug}/advanced${location.search}`} className="search-box-advanced-link">
+                <Link
+                  to={`/${match.params.datastoreSlug}/advanced${location.search}`}
+                  className="search-box-advanced-link"
+                >
                   <span className="offpage">{activeDatastore.name}</span>
                   <span>Advanced</span>
                   <span className="offpage">Search</span>
@@ -111,7 +125,7 @@ class SearchBox extends React.Component {
           </form>
         </div>
       </div>
-    )
+    );
   }
 }
 
@@ -121,20 +135,25 @@ function mapStateToProps(state) {
     query: state.search.query,
     queryInput: state.search.queryInput,
     activeFilters: state.filters.active[state.datastores.active],
-    activeDatastore: _.findWhere(state.datastores.datastores, { uid: state.datastores.active }),
+    activeDatastore: _.findWhere(state.datastores.datastores, {
+      uid: state.datastores.active,
+    }),
     location: state.router.location,
     isAdvanced: state.advanced[state.datastores.active] ? true : false,
     institution: state.institution,
     datastores: state.datastores,
-    sort: state.search.sort[state.datastores.active]
+    sort: state.search.sort[state.datastores.active],
   };
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({
-    setSearchQueryInput,
-    searching
-  }, dispatch)
+  return bindActionCreators(
+    {
+      setSearchQueryInput,
+      searching,
+    },
+    dispatch
+  );
 }
 
 export default withRouter(


### PR DESCRIPTION
Hotjar suppresses keystroke by default. This PR adds the `data-hj-allow` attribute to the basic and advanced search inputs.

Documentation: [How to Show Elements and Keystroke in Data Collection ](https://help.hotjar.com/hc/en-us/articles/115015563287-How-to-Show-Elements-and-Keystrokes-in-Data-Collection)