### PR TITLE
Add spaces between date descriptors (before/after) and the date

### DIFF
--- a/src/modules/advanced/components/AdvancedFilter/index.js
+++ b/src/modules/advanced/components/AdvancedFilter/index.js
@@ -27,17 +27,17 @@ const getDateRangeValue = ({ beginDateQuery, endDateQuery, selectedRange }) => {
       if (!endDateQuery) {
         return undefined
       }
-      return `before${endDateQuery}`
+      return `before ${endDateQuery}`
     case 'After':
       if (!beginDateQuery) {
         return undefined
       }
-      return `after${beginDateQuery}`
+      return `after ${beginDateQuery}`
     case 'Between':
       if (!beginDateQuery || !endDateQuery) {
         return undefined
       }
-      return `${beginDateQuery}to${endDateQuery}`
+      return `${beginDateQuery} to ${endDateQuery}`
     case 'In':
       if (!beginDateQuery) {
         return undefined


### PR DESCRIPTION
Noticed that there aren't spaces as described, resulting in
`after2002` as opposed to `after 2002`.