### PR TITLE
Testing updates

### DIFF
--- a/src/modules/pages/components/DatastorePage/container.js
+++ b/src/modules/pages/components/DatastorePage/container.js
@@ -17,7 +17,6 @@ import {
   DatastoreInfo,
   Landing,
   DatastoreAuthenticationAlert,
-  DatastoreAlerts,
 } from "../../../datastores";
 
 import { Filters } from "../../../filters";
@@ -131,7 +130,6 @@ class DatastorePageContainer extends React.Component {
                     },
                   }}
                 >
-                  <DatastoreAlerts />
                   <FlintAlerts />
                 </div>
                 <DatastoreAuthenticationAlert />

--- a/src/modules/records/components/RecordList/index.js
+++ b/src/modules/records/components/RecordList/index.js
@@ -42,7 +42,7 @@ class RecordListContainer extends React.Component {
           <div className="no-results-suggestions">
             <Heading level={2} size="small" style={{ marginTop: '0' }}>Other suggestions</Heading>
             <ul style={{ marginBottom: 0 }}>
-              <li>Try using the other options in the search navigation.</li>
+              <li>Try looking at the other search categories linked below the search box.</li>
               <li>Check your spelling.</li>
               <li>Try more general keywords.</li>
               <li>Try different keywords that mean the same thing.</li>

--- a/src/modules/records/components/RecordList/index.js
+++ b/src/modules/records/components/RecordList/index.js
@@ -46,6 +46,7 @@ class RecordListContainer extends React.Component {
               <li>Check your spelling.</li>
               <li>Try more general keywords.</li>
               <li>Try different keywords that mean the same thing.</li>
+               <li>Try using <a href={`${datastore.slug}/advanced`} className="underline">Advanced Search</a> to construct a targeted query.</li>
               <li>Use <a href="https://www.lib.umich.edu/ask-librarian" className="underline">Ask a Librarian</a> and we will help you find what you're looking for.</li>
             </ul>
           </div>


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses # [SEARCH-1280](https://tools.lib.umich.edu/jira/browse/SEARCH-1280) and [SEARCH-1287](https://tools.lib.umich.edu/jira/browse/SEARCH-1287)

SEARCH-1280 removes the COVID-19 alert from the front-end as it has been replaced with the alerts packaged with the universal header.

SEARCH-1287 updates the messaging a user receives when they have "No Results" for a search. I updated the list items with documentation provided to me. Additionally, there is now a dynamic link to Advanced Search that recognizes which datastore you are on and takes to to to the Advanced tab for that datastore.

### Type of change

- [x] Text/content fix (non-breaking change)

## How Has This Been Tested?

SEARCH-1280 The COVID-19 alert no longer appears.

SEARCH-1287 Inserting "_" into the Search bar gives No Results. I can see the updated text changes. Additionally, choosing the advanced search link now in the list, takes you to the datastore/advanced view. Ken V. tested it out as well.

### This has been tested on the following browser(s)

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Opera

## Preview

<img width="694" alt="1287 preview" src="https://user-images.githubusercontent.com/29953622/108226115-95193180-710a-11eb-8bf0-ac0a7acbb9a3.png">
Text for the "No Results" message.