### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+# Pull Request
+
+## Description
+
+This PR addresses # (issue/ticket number(s))
+
+Please describe the change. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+
+### Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change)
+- [ ] Text/content fix (non-breaking change)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions to reproduce. 
+
+- [ ] Test A
+- [ ] Test B
+
+### This has been testing on the following browser(s)
+
+- [ ] Chrome
+- [ ] Safari
+- [ ] Firefox
+- [ ] Opera
+
+## Preview
+
+Insert screen shot, video, or deploy preview link. Add captions for images.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] Test A
 - [ ] Test B
 
-### This has been testing on the following browser(s)
+### This has been tested on the following browser(s)
 
 - [ ] Chrome
 - [ ] Safari


### PR DESCRIPTION
This adds a pull request template to the repository. It is being put in the hidden GH directory but can be placed elsewhere if problematic.