### PR TITLE
SEARCH-1277 | Qp message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9160,6 +9160,11 @@
         "harmony-reflect": "^1.4.6"
       }
     },
+    "idle-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/idle-timeout/-/idle-timeout-2.0.1.tgz",
+      "integrity": "sha512-P26RMYHYajuCUxG7MG4DcggX8vmWWsEjfisUCT/l6OZ06sIAM9jWH8AeiGHAtm4JEGEv0fsY49U/BXOBdfCjSw=="
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -17730,6 +17735,7 @@
       "version": "git://github.com/mlibrary/prejudice.git#5c096752965ac74d69fc4ed86b540d92d4600b48",
       "from": "git://github.com/mlibrary/prejudice.git",
       "requires": {
+        "idle-timeout": "^2.0.1",
         "reqwest": "^2.0.5",
         "xhr2": "^0.1.4"
       }

--- a/src/modules/pages/components/DatastorePage/container.js
+++ b/src/modules/pages/components/DatastorePage/container.js
@@ -8,7 +8,7 @@ import { Route, Switch } from "react-router-dom";
 
 import { NoMatch } from "../../../pages";
 
-import { SearchBox, SearchParserMessage } from "../../../search";
+import { SearchBox } from "../../../search";
 
 import { AdvancedSearch } from "../../../advanced";
 
@@ -116,7 +116,6 @@ class DatastorePageContainer extends React.Component {
             render={() => (
               <React.Fragment>
                 <SearchBox />
-                <SearchParserMessage />
                 <DatastoreNavigation />
                 <div
                   css={{

--- a/src/modules/pride/components/URLSearchQueryWrapper/index.js
+++ b/src/modules/pride/components/URLSearchQueryWrapper/index.js
@@ -1,47 +1,40 @@
-import React from 'react'
-import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
-import { withRouter } from 'react-router-dom'
-import _ from 'underscore'
+import React from "react";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import { withRouter } from "react-router-dom";
+import _ from "underscore";
 
-import config from '../../../../config'
+import config from "../../../../config";
 import {
   setSearchQuery,
   setSearchQueryInput,
   searching,
   setPage,
   setSort,
-  resetSort
-} from '../../../search/actions'
-import {
-  loadingRecords
-} from '../../../records'
+  resetSort,
+  setParserMessage,
+} from "../../../search/actions";
+import { loadingRecords } from "../../../records";
 import {
   resetFilters,
   setActiveFilters,
-  clearActiveFilters
-} from '../../../filters'
+  clearActiveFilters,
+} from "../../../filters";
 import {
   getStateFromURL,
   runSearch,
   switchPrideToDatastore,
-  getDatastoreUidBySlug
-} from '../../../pride'
-import {
-  changeActiveDatastore,
-} from '../../../datastores'
-import {
-  setActiveInstitution
-} from '../../../institution'
-import {
-  setA11yMessage
-} from '../../../a11y'
+  getDatastoreUidBySlug,
+} from "../../../pride";
+import { changeActiveDatastore } from "../../../datastores";
+import { setActiveInstitution } from "../../../institution";
+import { setA11yMessage } from "../../../a11y";
 import { affiliationCookieSetter } from "../../../affiliation";
 
 class URLSearchQueryWrapper extends React.Component {
   constructor(props) {
-    super(props)
-    this.handleURLState = this.handleURLState.bind(this)
+    super(props);
+    this.handleURLState = this.handleURLState.bind(this);
   }
 
   handleURLState({
@@ -52,27 +45,25 @@ class URLSearchQueryWrapper extends React.Component {
     activeFilters,
     sort,
     location,
-    institution
+    institution,
   }) {
-    const urlState = getStateFromURL({ location })
-    let shouldRunSearch = false
+    const urlState = getStateFromURL({ location });
+    let shouldRunSearch = false;
 
-    affiliationCookieSetter(urlState.affiliation)
+    affiliationCookieSetter(urlState.affiliation);
 
     if (datastoreUid) {
-
       // URL has state
-      if ((Object.keys(urlState).length > 0)) {
-
+      if (Object.keys(urlState).length > 0) {
         // Query
         if (urlState.query && urlState.query !== query) {
-          this.props.setSearchQuery(urlState.query)
-          this.props.setSearchQueryInput(urlState.query)
+          this.props.setSearchQuery(urlState.query);
+          this.props.setSearchQueryInput(urlState.query);
 
-          shouldRunSearch = true
+          shouldRunSearch = true;
         } else if (!urlState.query && query) {
-          this.props.setSearchQuery('')
-          this.props.setSearchQueryInput('')
+          this.props.setSearchQuery("");
+          this.props.setSearchQueryInput("");
         }
 
         // Filters
@@ -80,32 +71,32 @@ class URLSearchQueryWrapper extends React.Component {
           if (urlState.filter) {
             this.props.setActiveFilters({
               datastoreUid,
-              filters: urlState.filter
-            })
+              filters: urlState.filter,
+            });
           } else {
             this.props.clearActiveFilters({
-              datastoreUid
-            })
+              datastoreUid,
+            });
           }
-          shouldRunSearch = true
+          shouldRunSearch = true;
         }
 
         // Page
-        const urlStatePage = parseInt(urlState.page, 10)
-        if (urlStatePage && (urlStatePage !== page)) {
+        const urlStatePage = parseInt(urlState.page, 10);
+        if (urlStatePage && urlStatePage !== page) {
           this.props.setPage({
             page: urlStatePage,
-            datastoreUid
-          })
+            datastoreUid,
+          });
 
-          shouldRunSearch = true
-        } else if (page && !urlStatePage && (page !== 1)) {
+          shouldRunSearch = true;
+        } else if (page && !urlStatePage && page !== 1) {
           this.props.setPage({
             page: 1,
-            datastoreUid
-          })
+            datastoreUid,
+          });
 
-          shouldRunSearch = true
+          shouldRunSearch = true;
         }
 
         // Sort
@@ -114,61 +105,63 @@ class URLSearchQueryWrapper extends React.Component {
           if (urlState.sort) {
             this.props.setSort({
               sort: urlState.sort,
-              datastoreUid
-            })
+              datastoreUid,
+            });
 
-            shouldRunSearch = true
+            shouldRunSearch = true;
 
-          // if no URL state
+            // if no URL state
           } else {
-            const configuredDefaultSort = config.sorts[datastoreUid].default
+            const configuredDefaultSort = config.sorts[datastoreUid].default;
 
             // Sort should be set to default
             if (sort !== configuredDefaultSort) {
               this.props.setSort({
                 sort: configuredDefaultSort,
-                datastoreUid
-              })
+                datastoreUid,
+              });
 
-              shouldRunSearch = true
+              shouldRunSearch = true;
             }
           }
         }
 
         // library aka institution
         if (urlState.library && urlState.library !== institution.active) {
-          this.props.setActiveInstitution(urlState.library)
+          this.props.setActiveInstitution(urlState.library);
 
           /*
             Users can change their library, but that does not trigger a search.
           */
-          const hasMoreThanLibraryInUrlState = Object.keys(urlState).filter(key => key !== 'library').length > 0
+          const hasMoreThanLibraryInUrlState =
+            Object.keys(urlState).filter((key) => key !== "library").length > 0;
 
           if (hasMoreThanLibraryInUrlState) {
-            shouldRunSearch = true
+            shouldRunSearch = true;
           }
         }
 
         if (shouldRunSearch) {
-          this.props.setA11yMessage(`Search modified.`)
-          runSearch()
+          this.props.setA11yMessage(`Search modified.`);
+          this.props.setParserMessage(null);
+          runSearch();
         }
+      } else {
+        // URL does not have state,
+        this.props.resetFilters();
 
-      } else { // URL does not have state,
-        this.props.resetFilters()
-        
         /*
           You shouldn't do this in React, but this is being asked
           and better than handling a ref across concerns
         */
-        let el = document.getElementById('search-query')
+        let el = document.getElementById("search-query");
         if (el) {
-          el.value = ""
+          el.value = "";
         }
-        
+
         // Reset query
         if (query.length > 0) {
-          this.props.setSearchQuery('')
+          this.props.setSearchQuery("");
         }
       }
 
@@ -182,18 +175,20 @@ class URLSearchQueryWrapper extends React.Component {
           2. URL contains a filter.
       */
       if (urlState.query || urlState.filter) {
-        this.props.searching(true)
+        this.props.searching(true);
       } else {
-        this.props.searching(false)
+        this.props.searching(false);
       }
     }
   }
 
   componentWillReceiveProps(nextProps) {
-    const datastoreUid = getDatastoreUidBySlug(nextProps.match.params.datastoreSlug)
+    const datastoreUid = getDatastoreUidBySlug(
+      nextProps.match.params.datastoreSlug
+    );
 
     if (this.props.datastoreUid !== datastoreUid) {
-      switchPrideToDatastore(datastoreUid)
+      switchPrideToDatastore(datastoreUid);
     }
 
     this.handleURLState({
@@ -204,16 +199,12 @@ class URLSearchQueryWrapper extends React.Component {
       datastoreUid: datastoreUid,
       page: nextProps.page[datastoreUid],
       sort: nextProps.sort[datastoreUid],
-      institution: nextProps.institution
-    })
+      institution: nextProps.institution,
+    });
   }
 
   render() {
-    return (
-      <div>
-        {this.props.children}
-      </div>
-    )
+    return <div>{this.props.children}</div>;
   }
 }
 
@@ -227,28 +218,32 @@ function mapStateToProps(state) {
     datastoreUid: state.datastores.active,
     isSearching: state.search.searching,
     institution: state.institution,
-    sort: state.search.sort
+    sort: state.search.sort,
   };
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({
-    setSearchQuery,
-    setSearchQueryInput,
-    setActiveFilters,
-    clearActiveFilters,
-    resetFilters,
-    searching,
-    loadingRecords,
-    changeActiveDatastore,
-    setPage,
-    setSort,
-    resetSort,
-    setActiveInstitution,
-    setA11yMessage
-  }, dispatch)
+  return bindActionCreators(
+    {
+      setSearchQuery,
+      setSearchQueryInput,
+      setActiveFilters,
+      clearActiveFilters,
+      resetFilters,
+      searching,
+      loadingRecords,
+      changeActiveDatastore,
+      setPage,
+      setSort,
+      resetSort,
+      setActiveInstitution,
+      setA11yMessage,
+      setParserMessage,
+    },
+    dispatch
+  );
 }
 
 export default withRouter(
   connect(mapStateToProps, mapDispatchToProps)(URLSearchQueryWrapper)
-)
+);

--- a/src/modules/records/components/RecordList/index.js
+++ b/src/modules/records/components/RecordList/index.js
@@ -6,7 +6,7 @@ import Record from '../Record';
 import Sorts from '../Sorts';
 import RecordPlaceholder from '../RecordPlaceholder';
 import { Heading } from '@umich-lib/core'
-import { SearchParserMessage2 } from "../../../search";
+import { SearchResultsMessage } from "../../../search";
 
 
 import {
@@ -89,7 +89,7 @@ class RecordListContainer extends React.Component {
         <div className="results-summary-container">
           <ResultsSummary />
           <Sorts />
-          <SearchParserMessage2 />
+          <SearchResultsMessage />
         </div>
         <GoToList list={list} datastore={datastore} />
         <div className="results-list results-list-border search-results" id="search-results">

--- a/src/modules/records/components/RecordList/index.js
+++ b/src/modules/records/components/RecordList/index.js
@@ -6,6 +6,8 @@ import Record from '../Record';
 import Sorts from '../Sorts';
 import RecordPlaceholder from '../RecordPlaceholder';
 import { Heading } from '@umich-lib/core'
+import { SearchParserMessage2 } from "../../../search";
+
 
 import {
   ResultsSummary,
@@ -87,6 +89,7 @@ class RecordListContainer extends React.Component {
         <div className="results-summary-container">
           <ResultsSummary />
           <Sorts />
+          <SearchParserMessage2 />
         </div>
         <GoToList list={list} datastore={datastore} />
         <div className="results-list results-list-border search-results" id="search-results">

--- a/src/modules/search/components/SearchParserMessage2/index.js
+++ b/src/modules/search/components/SearchParserMessage2/index.js
@@ -5,10 +5,38 @@ import { Icon } from "@umich-lib/core";
 import { COLORS } from "../../../reusable/umich-lib-core-temp";
 
 export default function SearchParserMessage2() {
-  const { parserMessage } = useSelector((state) => state.search);
-
+  const { parserMessage, query } = useSelector((state) => state.search);
+  
+  //Check if there is a message from the parser and render the query if no message
   if (!parserMessage) {
-    return null;
+    return (
+      <section
+      className="parser-message"
+      css={{
+        width: `100%`,
+        color: COLORS.neutral["400"],
+      }}
+    >
+      <p>
+        <strong
+          css={{
+            fontWeight: "600",
+            color: COLORS.neutral["400"],
+          }}
+        >
+          Showing results for:{" "}
+        </strong>
+        <strong
+          css={{
+            fontWeight: "600",
+            color: "#0C5292",
+          }}
+        >
+          {query} 
+          </strong>
+        </p>
+       </section>
+    )
   }
 
   return (
@@ -34,7 +62,7 @@ export default function SearchParserMessage2() {
             color: "#0C5292",
           }}
         >
-          {parserMessage.details}
+          {parserMessage.data.actual}
         </strong>
       </p>
 
@@ -46,7 +74,7 @@ export default function SearchParserMessage2() {
             fontSize: "1em",
           }}
         >
-          {parserMessage.class}
+          {parserMessage.data.original}
         </strong>
       </p>
 
@@ -57,7 +85,7 @@ export default function SearchParserMessage2() {
             color: COLORS.orange["500"],
           }}
         >
-          <Icon icon="error" size={20} /> Summary: {parserMessage.summary}
+          <Icon icon="error" size={20} /> {parserMessage.data.details}
         </strong>
       </p>
     </section>

--- a/src/modules/search/components/SearchParserMessage2/index.js
+++ b/src/modules/search/components/SearchParserMessage2/index.js
@@ -1,0 +1,72 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import store from "./../../../../store";
+import { setParserMessage } from "../../../search";
+import { useSelector } from "react-redux";
+import { Icon } from "@umich-lib/core";
+
+export default function SearchParserMessage2() {
+  const { parserMessage } = useSelector((state) => state.search);
+  const isOpen = parserMessage !== null;
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    store.dispatch(setParserMessage(null));
+  };
+
+  return (
+    <section
+        className="parser-message"
+          css={{
+            width: `100%`,
+            color: "#333"
+          }}
+        >
+        <p>
+          <strong
+            css={{
+             fontWeight: "600",
+              color: "#333"
+          }}
+          >
+          Showing results for:{" "}
+          </strong>
+          <strong
+          css={{
+            fontWeight: "600",
+             color: "#0C5292"
+           }}>
+           {parserMessage.details}
+            </strong>
+        </p>
+        
+      <p>
+        You searched for:{" "}
+        <strong
+            css={{
+            fontWeight: "600",
+              fontSize: "1em"
+              }}>
+          {parserMessage.class}
+        </strong>
+              
+            </p>
+        
+        <p>
+            <strong
+                css={{
+                  fontWeight: "600",
+                  color: "#AA5600"
+                }}
+        >
+           <Icon icon="error" size={20} />
+          {" "}Summary:{" "}
+          {parserMessage.summary}
+              </strong>
+            </p>
+      </section>
+  );
+}

--- a/src/modules/search/components/SearchParserMessage2/index.js
+++ b/src/modules/search/components/SearchParserMessage2/index.js
@@ -11,24 +11,20 @@ export default function SearchParserMessage2() {
   if (!parserMessage) {
     return (
       <section
-      className="parser-message"
+      className="results-message"
       css={{
         width: `100%`,
         color: COLORS.neutral["400"],
       }}
     >
-      <p>
-        <strong
-          css={{
+      <p css={{
             fontWeight: "600",
-            color: COLORS.neutral["400"],
-          }}
-        >
+          }}>
+        <strong>
           Showing results for:{" "}
         </strong>
         <strong
           css={{
-            fontWeight: "600",
             color: "#0C5292",
           }}
         >
@@ -47,10 +43,12 @@ export default function SearchParserMessage2() {
         color: COLORS.neutral["400"],
       }}
     >
-      <p>
+      <p
+      css={{
+            fontWeight: "600",
+          }}>
         <strong
           css={{
-            fontWeight: "600",
             color: COLORS.neutral["400"],
           }}
         >
@@ -58,7 +56,6 @@ export default function SearchParserMessage2() {
         </strong>
         <strong
           css={{
-            fontWeight: "600",
             color: "#0C5292",
           }}
         >
@@ -66,12 +63,15 @@ export default function SearchParserMessage2() {
         </strong>
       </p>
 
-      <p>
+      <p css={{
+        fontSize: ".8em",
+        paddingBottom: ".5em",
+          }}
+          >
         You searched for:{" "}
         <strong
           css={{
             fontWeight: "600",
-            fontSize: "1em",
           }}
         >
           {parserMessage.data.original}
@@ -82,10 +82,12 @@ export default function SearchParserMessage2() {
         <strong
           css={{
             fontWeight: "600",
-            color: COLORS.orange["500"],
+            color: "#AA5600",
+            fontSize: ".8em",
           }}
         >
-          <Icon icon="error" size={20} /> {parserMessage.data.details}
+          <Icon icon="warning" size={14} />
+          {parserMessage.data.details} 
         </strong>
       </p>
     </section>

--- a/src/modules/search/components/SearchParserMessage2/index.js
+++ b/src/modules/search/components/SearchParserMessage2/index.js
@@ -1,15 +1,13 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import store from "./../../../../store";
-import { setParserMessage } from "../../../search";
 import { useSelector } from "react-redux";
 import { Icon } from "@umich-lib/core";
+import { COLORS } from "../../../reusable/umich-lib-core-temp";
 
 export default function SearchParserMessage2() {
   const { parserMessage } = useSelector((state) => state.search);
-  const isOpen = parserMessage !== null;
 
-  if (!isOpen) {
+  if (!parserMessage) {
     return null;
   }
 
@@ -18,14 +16,14 @@ export default function SearchParserMessage2() {
       className="parser-message"
       css={{
         width: `100%`,
-        color: "#333",
+        color: COLORS.neutral["400"],
       }}
     >
       <p>
         <strong
           css={{
             fontWeight: "600",
-            color: "#333",
+            color: COLORS.neutral["400"],
           }}
         >
           Showing results for:{" "}
@@ -56,7 +54,7 @@ export default function SearchParserMessage2() {
         <strong
           css={{
             fontWeight: "600",
-            color: "#AA5600",
+            color: COLORS.orange["500"],
           }}
         >
           <Icon icon="error" size={20} /> Summary: {parserMessage.summary}

--- a/src/modules/search/components/SearchParserMessage2/index.js
+++ b/src/modules/search/components/SearchParserMessage2/index.js
@@ -13,60 +13,55 @@ export default function SearchParserMessage2() {
     return null;
   }
 
-  const handleDismiss = () => {
-    store.dispatch(setParserMessage(null));
-  };
-
   return (
     <section
-        className="parser-message"
-          css={{
-            width: `100%`,
-            color: "#333"
-          }}
-        >
-        <p>
-          <strong
-            css={{
-             fontWeight: "600",
-              color: "#333"
-          }}
-          >
-          Showing results for:{" "}
-          </strong>
-          <strong
+      className="parser-message"
+      css={{
+        width: `100%`,
+        color: "#333",
+      }}
+    >
+      <p>
+        <strong
           css={{
             fontWeight: "600",
-             color: "#0C5292"
-           }}>
-           {parserMessage.details}
-            </strong>
-        </p>
-        
+            color: "#333",
+          }}
+        >
+          Showing results for:{" "}
+        </strong>
+        <strong
+          css={{
+            fontWeight: "600",
+            color: "#0C5292",
+          }}
+        >
+          {parserMessage.details}
+        </strong>
+      </p>
+
       <p>
         You searched for:{" "}
         <strong
-            css={{
+          css={{
             fontWeight: "600",
-              fontSize: "1em"
-              }}>
+            fontSize: "1em",
+          }}
+        >
           {parserMessage.class}
         </strong>
-              
-            </p>
-        
-        <p>
-            <strong
-                css={{
-                  fontWeight: "600",
-                  color: "#AA5600"
-                }}
+      </p>
+
+      <p>
+        <strong
+          css={{
+            fontWeight: "600",
+            color: "#AA5600",
+          }}
         >
-           <Icon icon="error" size={20} />
-          {" "}Summary:{" "}
-          {parserMessage.summary}
-              </strong>
-            </p>
-      </section>
+          <Icon icon="error" size={20} /> Summary: {parserMessage.summary}
+        </strong>
+      </p>
+    </section>
   );
 }

--- a/src/modules/search/components/SearchResultsMessage/index.js
+++ b/src/modules/search/components/SearchResultsMessage/index.js
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { Icon } from "@umich-lib/core";
 import { COLORS } from "../../../reusable/umich-lib-core-temp";
 
-export default function SearchParserMessage2() {
+export default function SearchResultsMessage() {
   const { parserMessage, query } = useSelector((state) => state.search);
   
   //Check if there is a message from the parser and render the query if no message
@@ -16,8 +16,9 @@ export default function SearchParserMessage2() {
         width: `100%`,
         color: COLORS.neutral["400"],
       }}
-    >
-      <p css={{
+      >
+        <p
+          css={{
             fontWeight: "600",
           }}>
         <strong>
@@ -29,7 +30,7 @@ export default function SearchParserMessage2() {
           }}
         >
           {query} 
-          </strong>
+        </strong>
         </p>
        </section>
     )
@@ -52,7 +53,7 @@ export default function SearchParserMessage2() {
             color: COLORS.neutral["400"],
           }}
         >
-          Showing results for:{" "}
+        Showing results for:{" "}
         </strong>
         <strong
           css={{

--- a/src/modules/search/index.js
+++ b/src/modules/search/index.js
@@ -1,7 +1,7 @@
 import SearchBox from "./components/SearchBox";
 import ClearSearchButton from "./components/ClearSearchButton";
 import SearchParserMessage from "./components/SearchParserMessage";
-import SearchParserMessage2 from "./components/SearchParserMessage2";
+import SearchResultsMessage from "./components/SearchResultsMessage";
 
 import searchReducer from "./reducer";
 import {
@@ -28,5 +28,5 @@ export {
   resetSort,
   setParserMessage,
   SearchParserMessage,
-  SearchParserMessage2
+  SearchResultsMessage
 };

--- a/src/modules/search/index.js
+++ b/src/modules/search/index.js
@@ -1,6 +1,7 @@
 import SearchBox from "./components/SearchBox";
 import ClearSearchButton from "./components/ClearSearchButton";
 import SearchParserMessage from "./components/SearchParserMessage";
+import SearchParserMessage2 from "./components/SearchParserMessage2";
 
 import searchReducer from "./reducer";
 import {
@@ -27,4 +28,5 @@ export {
   resetSort,
   setParserMessage,
   SearchParserMessage,
+  SearchParserMessage2
 };

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -730,10 +730,17 @@ textarea {
   @media (min-width: 600px) {
     .results-summary-container {
       display: flex;
+      flex-flow: row wrap;
       justify-content: space-between;
       align-items: center; }
       .results-summary-container > * {
         margin-top: 0; } }
+  .parser-message {
+    padding-top: .25em;
+  }
+  .parser-message p {
+    margin: .5em 0;
+  }
 
 .no-results-suggestions {
   background: #FAFAFA;

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -735,12 +735,12 @@ textarea {
       align-items: center; }
       .results-summary-container > * {
         margin-top: 0; } }
-  .parser-message {
-    padding-top: .25em;
-  }
-  .parser-message p {
-    margin: .5em 0;
-  }
+    .parser-message, .results-message {
+      padding-top: .25em;
+    }
+    .parser-message p, .results-message p {
+      margin: .25em 0;
+    }
 
 .no-results-suggestions {
   background: #FAFAFA;


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses # SEARCH-1277

Replaces the parser message modal component(SearchParserMessage) to a message component in the results container (SearchResultsMessage) on the RecordList. A search query should show under the number of results and if the QP changed the query, the message appears. The message won't show unless running the parser_testing_1 data.

To test locally, pull branch and `npm run start:kub`

### Type of change

- [X] New feature (non-breaking change which adds functionality)


### This has been tested on the following browser(s), in large and small screens:

- [X] Chrome
- [X] Safari
- [X] Firefox
- [X] Opera

## Preview

<img width="1018" alt="Search results screenshot showing results of query and error message" src="https://user-images.githubusercontent.com/29953622/110973218-f22f8e00-832a-11eb-9d3d-b6e6bcba3c82.png">


