### PR TITLE
SEARCH-1342 Remove in-page Covid Datastore Alert for production.

### DIFF
--- a/src/modules/pages/components/DatastorePage/container.js
+++ b/src/modules/pages/components/DatastorePage/container.js
@@ -17,7 +17,6 @@ import {
   DatastoreInfo,
   Landing,
   DatastoreAuthenticationAlert,
-  DatastoreAlerts,
 } from "../../../datastores";
 
 import { Filters } from "../../../filters";
@@ -130,7 +129,6 @@ class DatastorePageContainer extends React.Component {
                     },
                   }}
                 >
-                  <DatastoreAlerts />
                   <FlintAlerts />
                 </div>
                 <DatastoreAuthenticationAlert />


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses # SEARCH-1342

We previously removed the in-page COVID Datastore alert message on testing in order to use the new website alert system. In transitioning the use of the UH system on Search, we are removing this duplicate messaging system.

### Type of change

Please delete options that are not relevant.
- [X] Text/content fix (non-breaking change)

## How Has This Been Tested?

### This has been tested on the following browser(s)

- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] Opera

## Preview

<img width="1201" alt="Home page of the Search application" src="https://user-images.githubusercontent.com/29953622/114064493-b6271480-9867-11eb-8d8c-c465602abbec.png">

[Preview](https://deploy-preview-278--umich-lib-search-dev.netlify.app/)
