### PR TITLE
"My Account" => "Account" -- SEARCH-1394

### DIFF
--- a/src/modules/core/components/SearchHeader/index.js
+++ b/src/modules/core/components/SearchHeader/index.js
@@ -15,7 +15,7 @@ class SearchHeader extends React.Component {
     const loginText = this.props.isAuthenticated ? "Log out" : "Log in";
     const loginHref = this.props.isAuthenticated ? logoutUrl : loginUrl;
     let navItems = [
-      { text: "My Account", href: "https://apps.lib.umich.edu/my-account" },
+      { text: "Account", href: "https://account.lib.umich.edu/" },
       {
         text: "My Favorites",
         href: "https://apps.lib.umich.edu/my-account/favorites",


### PR DESCRIPTION
"My Account" has be named to just "Account" and it now lives at account.lib.umich.edu. This PR changes that link.