### PR TITLE
Redirect if we have a record w/ wrong, aleph-looking id

### DIFF
--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -80,8 +80,12 @@ class FullRecord extends React.Component {
 
     // If the record isn't in state
     if (record && record.uid !== recordUid) {
-        if (recordUid.length === 9) { // treat as an aleph id
+        if (datastoreUid == 'mirlyn' && recordUid.length === 9) {
+            // treat as an aleph id
             history.push(`/catalog/record/${record.uid}`)
+        } else if (datastoreUid == 'onlinejournals' && recordUid.length == 0) {
+            // treat as an aleph id
+            history.push(`/onlinejournals/record/${record.uid}`)
         } else {
             requestRecord({recordUid, datastoreUid});
         }

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -80,10 +80,10 @@ class FullRecord extends React.Component {
 
     // If the record isn't in state
     if (record && record.uid !== recordUid) {
-        if (datastoreUid == 'mirlyn' && recordUid.length === 9) {
+        if (datastoreUid === 'mirlyn' && recordUid.length === 9) {
             // treat as an aleph id
             history.push(`/catalog/record/${record.uid}`)
-        } else if (datastoreUid == 'onlinejournals' && recordUid.length == 0) {
+        } else if (datastoreUid === 'onlinejournals' && recordUid.length === 9) {
             // treat as an aleph id
             history.push(`/onlinejournals/record/${record.uid}`)
         } else {

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -75,12 +75,16 @@ class FullRecord extends React.Component {
   }
 
   componentDidUpdate() {
-    const { record, datastoreUid, datastores } = this.props;
+    const { record, datastoreUid, datastores, history } = this.props;
     const { recordUid } = this.props.match.params;
 
     // If the record isn't in state
     if (record && record.uid !== recordUid) {
-      requestRecord({ recordUid, datastoreUid });
+        if (recordUid.length === 9) { // treat as an aleph id
+            history.push(`/catalog/record/${record.uid}`)
+        } else {
+            requestRecord({recordUid, datastoreUid});
+        }
     }
 
     if (record) {


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses # SEARCH-1358

When someone goes to a record page with a 9-digit ID, and we get a record back that doesn't match ID, assume that we've gotten an aleph ID and redirect to the id in the id field on the record.

I have no idea if this is the right way to do this - it worked well enough for testing, but I don't know React idioms. Spectrum PR [https://github.com/mlibrary/spectrum-json/pull/25](#25) - redirect from old aleph_id to new alma id) requires this or some similar change for the user to actually see the record they asked for instead of Search infinitely looping trying to fetch a record with a matching ID in the `id` field.

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change)
- [X] New feature (non-breaking change which adds functionality) **(I think?)**
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions to reproduce. 

- [X] Grab an aleph ID from some catalog record that's available in the solr you're pulling from. Go to `[base_url]/catalog/record/[aleph_id]`. Should redirect to `[base_url]/catalog/record/[alma id]` and show the record you expect.

### This has been tested on the following browser(s)

- [ ] Chrome
- [ ] Safari
- [X] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [ ] WAVE
- [ ] Accessibility Insights
- [ ] axe
- [ ] Other

