### PR TITLE
Check alt_ids on full record pages.

### DIFF
--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -67,6 +67,7 @@ class FullRecord extends React.Component {
   componentWillMount() {
     const { recordUid } = this.props.match.params;
     const { datastoreUid } = this.props;
+    const { datastore } = this.props.datastore
 
     requestRecord({ recordUid, datastoreUid });
     prejudiceInstance = prejudice.createVariableStorageDriverInstance();
@@ -75,7 +76,7 @@ class FullRecord extends React.Component {
   }
 
   componentDidUpdate() {
-    const { record, datastoreUid, datastores, history } = this.props;
+    const { record, datastoreUid, datastores, history, datastore } = this.props;
     const { recordUid } = this.props.match.params;
 
     // If the record isn't in state
@@ -86,6 +87,8 @@ class FullRecord extends React.Component {
         } else if (datastoreUid === 'onlinejournals' && recordUid.length === 9) {
             // treat as an aleph id
             history.push(`/onlinejournals/record/${record.uid}`)
+        } else if (_.contains(record.alt_ids, recordUid)) {
+            history.push(`/${datastore.slug}/record/${record.uid}`)
         } else {
             requestRecord({recordUid, datastoreUid});
         }


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses DNDHELP-3024

Summon IDs are, at least in some cases, retrievable in Primo via an `id` search.  Except the resulting record has uid set to the Primo ID.  So, Search continuously reloads the record, finding a different id than the one in the url.

New feature:  in Spectrum, add an alt_ids attribute to the records.  If the record id from the state is not the record id from Spectrum, but is one of the alt_ids on the record, do a redirect to the record id from Spectrum.

### Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions to reproduce. 

- [ ] Visit https://search-staging.www.lib.umich.edu/articles/record/FETCH-LOGICAL-12340-79e57e6e01f153e5aae920a46f9083ab7cbe424cb71df470214cb6bbb881115f3
- [ ] Observe that the url gets changed to https://search-staging.www.lib.umich.edu/articles/record/cdi_proquest_journals_1289588125

### This has been tested on the following browser(s)

- [x] Chrome
- [ ] Safari
- [x] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

No new UI behaviors or markup was introduced.  All UI behavior was included in redirects for the catalog already.

## Preview

https://search-staging.www.lib.umich.edu/articles/record/FETCH-LOGICAL-12340-79e57e6e01f153e5aae920a46f9083ab7cbe424cb71df470214cb6bbb881115f3

