### PR TITLE
Search 1481 no more etas in get this

### DIFF
--- a/src/modules/getthis/components/GetThisFAQ/index.js
+++ b/src/modules/getthis/components/GetThisFAQ/index.js
@@ -3,17 +3,6 @@ import { Heading } from '@umich-lib/core'
 
 const GetThisFAQ = () => (
   <section className="card get-this-section">
-    <Heading size="medium" level={3} style={{ marginTop: 0 }}>Frequently asked questions</Heading>
-
-    <Heading size="small" level={4}>When can I request a physical copy for contactless pickup?</Heading>
-    <p className="u-margin-top-none">Many items in our physical collection have been digitized and made available through the HathiTrust Digital Library. When this is the case, you'll see “Full text available online."</p>
-
-    <p className="u-margin-top-none">For physical items from our collection that aren't digitized and available through HathiTrust, you'll see an option for "Contactless pickup at the library."</p>
-
-
-    <Heading size="small" level={4}>What should I do if an item has multiple volumes and the one I need isn’t available in HathiTrust or for contactless pickup?</Heading>
-    
-    <p className="u-margin-top-none">When titles available through HathiTrust Digital Library have multiple volumes, we have to set the whole group as “Full text available online” even if some volumes are not digitized. If the one you need is not available in HathiTrust, please contact <a href="mailto:circservices@umich.edu" className="underline">circservices@umich.edu</a>.</p>
 
   </section>
 )

--- a/src/modules/getthis/components/GetThisFAQ/index.js
+++ b/src/modules/getthis/components/GetThisFAQ/index.js
@@ -10,11 +10,10 @@ const GetThisFAQ = () => (
 
     <p className="u-margin-top-none">For physical items from our collection that aren't digitized and available through HathiTrust, you'll see an option for "Contactless pickup at the library."</p>
 
-    <p className="u-margin-top-none">Due to copyright limitations, we cannot check out multiple copies of an item that has been digitized, which means the HathiTrust version may be the only option available.</p>
 
     <Heading size="small" level={4}>What should I do if an item has multiple volumes and the one I need isn’t available in HathiTrust or for contactless pickup?</Heading>
     
-    <p className="u-margin-top-none">When titles available through HathiTrust Digital Library have multiple volumes, we have to set the whole group as “Full text available online” even if some volumes are not digitized. If the one you need is not available in HathiTrust, please contact <a href="mailto:glcirc@umich.edu" className="underline">glcirc@umich.edu</a>.</p>
+    <p className="u-margin-top-none">When titles available through HathiTrust Digital Library have multiple volumes, we have to set the whole group as “Full text available online” even if some volumes are not digitized. If the one you need is not available in HathiTrust, please contact <a href="mailto:circservices@umich.edu" className="underline">circservices@umich.edu</a>.</p>
 
   </section>
 )

--- a/src/modules/getthis/components/GetThisForm/index.js
+++ b/src/modules/getthis/components/GetThisForm/index.js
@@ -155,7 +155,7 @@ class GetThisForm extends React.Component {
 
             <p><b>Status:</b> {response.status}</p>
 
-            <p class="u-margin-bottom-none">Please contact the Graduate Library Circulation Desk at <a href="mailto:glcirc@umich.edu" className="underline">glcirc@umich.edu</a> or <a href="tel:7347640401" className="underline">(734) 764-0401</a> for assistance.</p>
+            <p class="u-margin-bottom-none">Please contact the Graduate Library Circulation Desk at <a href="mailto:circservices@umich.edu" className="underline">circservices@umich.edu</a> or <a href="tel:7347640401" className="underline">(734) 764-0401</a> for assistance.</p>
           </article>
         )
       }


### PR DESCRIPTION
# Pull Request

@jonearley Can we get rid of the GetThis FAQ entirely? Not sure how to actually do that or test this change in general.

## Description

This PR addresses #1481
Takes out the FAQ


### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change)
- [ ] Text/content fix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions to reproduce. 

- [ ] Test A
- [ ] Test B

### This has been tested on the following browser(s)

- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [ ] WAVE
- [ ] Accessibility Insights
- [ ] axe
- [ ] Other

## Preview

Insert screen shot, video, or deploy preview link. Add captions for images.

