### PR TITLE
Remove hard-coded list of fields to parenthesize for QP

### DIFF
--- a/src/modules/advanced/components/AdvancedSearchForm/index.js
+++ b/src/modules/advanced/components/AdvancedSearchForm/index.js
@@ -73,20 +73,7 @@ class AdvancedSearchForm extends React.Component {
           if (memo.length > 0) {
             memo.push(booleanTypes[fieldedSearch.booleanType]);
           }
-
-          // Listed hard-coded fields should have a parentheses
-          // TODO: remove after query parser update
-          if (
-            fieldedSearch.field === "all_fields" ||
-            fieldedSearch.field === "author" ||
-            fieldedSearch.field === "title" ||
-            fieldedSearch.field === "subject" ||
-            (fieldedSearch.field === "series" && datastore.uid === "mirlyn")
-          ) {
-            memo.push(`${fieldedSearch.field}:(${fieldedSearch.query})`);
-          } else {
-            memo.push(`${fieldedSearch.field}:${fieldedSearch.query}`);
-          }
+          memo.push(`${fieldedSearch.field}:(${fieldedSearch.query})`);
         }
 
         return memo;


### PR DESCRIPTION
All fields from the advanced search form should be getting parentheses

# Pull Request

## Description

This PR addresses # DNDHELP-3168

A user did this search:
Latino OR Latina OR Latinx OR “Latin American” OR Hispanic OR “Hispanic American”
AND
immigrant OR immigration
AND
“United States”
AND
music OR musicians
They expected something like
`keyword:(Latino OR Latina OR Latinx OR "Latin American" OR Hispanic OR "Hispanic American") AND keyword:(immigrant OR immigration) AND keyword:("United States") AND keyword:(music OR musicians)`
but ended up with
`keyword:Latino OR Latina OR Latinx OR "Latin American" OR Hispanic OR "Hispanic American" AND keyword:immigrant OR immigration AND keyword:"United States" AND keyword:music OR musicians`


### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions to reproduce. 

- [X] On a local instance, I entered a search across multiple `Keyword` lines in the catalog Advanced Search Form and confirmed that prior to the change, I got the above-cited wrong output, and following the change, I got the above-cited correct output

### This has been tested on the following browser(s)

- [ ] Chrome
- [ ] Safari
- [X] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [ ] WAVE
- [ ] Accessibility Insights
- [ ] axe
- [ ] Other
