### PR TITLE
[SEARCH-1521] Update copyright in footer of Search to reflect current year

### DIFF
--- a/src/modules/core/components/Footer/index.js
+++ b/src/modules/core/components/Footer/index.js
@@ -70,7 +70,7 @@ const Footer = () => {
         </ul>
 
         <p>
-          ©2018 Regents of the University of Michigan. For details and
+          &copy;{(new Date().getFullYear())} Regents of the University of Michigan. For details and
           exceptions, see the{" "}
           <a href="https://lib.umich.edu/about-us/policies/copyright-policy">
             Copyright Policy


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [SEARCH-1521](https://tools.lib.umich.edu/jira/browse/SEARCH-1521).

The copyright year in the footer was static text, and has not been updated since `2018`. This pull request updates that so it will automatically change every year.


### Type of change

- [x] Bug fix (non-breaking change)
- [x] Text/content fix (non-breaking change)

## How Has This Been Tested?

This has been tested on `localhost`. Several pages have been looked at to see if the footer has been updated throughout.

### This has been tested on the following browser(s)

- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Opera

