### PR TITLE
[SEARCH-1564] Browse Tip Typos

### DIFF
--- a/src/modules/search/search-options.js
+++ b/src/modules/search/search-options.js
@@ -2,47 +2,47 @@ const searchOptions = [
   {
     "label": "Keyword",
     "value": "keyword",
-    "tip": "Enter one or more keywords. Use quotes to search for a phrase. (e.g. solar power; polar bears; “systems of oppression”) See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>."
+    "tip": "Enter one or more keywords. Use quotes to search for a phrase (e.g. solar power; polar bears; “systems of oppression”). See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>."
   },
   {
     "label": "Title",
     "value": "title",
-    "tip": "Enter the first words in a title. Use quotes to search a phrase. (e.g. One Hundred Years of Solitude; “The Fourth World”; Disability Visibility)"
+    "tip": "Enter the first words in a title. Use quotes to search a phrase (e.g. One Hundred Years of Solitude; “The Fourth World”; Disability Visibility)."
   },
   {
     "label": "Title starts with",
     "value": "title_starts_with",
-    "tip": "Search for titles that begin with a word or phrase. (e.g., introduction to chemistry; history of Mexico; Asian art)"
+    "tip": "Search for titles that begin with a word or phrase (e.g., introduction to chemistry; history of Mexico; Asian art)."
   },
   {
     "label": "Author",
     "value": "author",
-    "tip": "Search for items by author or contributor. Also search organizations or corporate authors. (e.g. Kimmerer, Robin Wall; American Medical Association; 小川 洋子)"
+    "tip": "Search for items by author or contributor. Also search organizations or corporate authors (e.g. Kimmerer, Robin Wall; American Medical Association; 小川 洋子)."
   },
   {
     "label": "Journal/Serial Title",
     "value": "journal_title",
-    "tip": "Search the title of a journal or serial publication. (e.g. Detroit Free Press; “journal of the american medical association”; African-American newspapers)"
+    "tip": "Search the title of a journal or serial publication (e.g. Detroit Free Press; “journal of the american medical association”; African-American newspapers)."
   },
   {
     "label": "Subject",
     "value": "subject",
-    "tip": "Use words or phrases to search subject headings. (e.g., public health; radicalism--united states; Baldwin, James)"
+    "tip": "Use words or phrases to search subject headings (e.g., public health; radicalism--united states; Baldwin, James)."
   },
   {
     "label": "Academic Discipline",
     "value": "academic_discipline",
-    "tip": "Search academic disciplines. <a href=\"https://search.lib.umich.edu/databases/browse?query=sculpture\">Browse all Databases</a> alphabetically or by academic discipline. (e.g. International business; Latin american and caribbean studies)"
+    "tip": "Search academic disciplines. <a href=\"https://search.lib.umich.edu/databases/browse?query=sculpture\">Browse all Databases</a> alphabetically or by academic discipline (e.g. International business; Latin american and caribbean studies)."
   },
   {
     "label": "Call Number starts with",
     "value": "call_number_starts_with",
-    "tip": "Search the first few letters and numbers of a call number. (e.g. RC662.4 .H38 2016; QH 105) <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>."
+    "tip": "Search the first few letters and numbers of a call number (e.g. RC662.4 .H38 2016; QH 105). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>."
   },
   {
     "label": "Series (transcribed)",
     "value": "series",
-    "tip": "Search the series title of a group of thematically-related books. Use ‘title’ search to find unique titles within a series. (e.g., Politics of Race and Ethnicity, Brill's Annotated Bibliographies, Oxford Choral Music)"
+    "tip": "Search the series title of a group of thematically-related books. Use ‘title’ search to find unique titles within a series (e.g., Politics of Race and Ethnicity, Brill's Annotated Bibliographies, Oxford Choral Music)."
   },
   {
     "label": "Year of Publication",
@@ -52,30 +52,30 @@ const searchOptions = [
   {
     "label": "ISBN/ISSN/OCLC/etc",
     "value": "isn",
-    "tip": "Search by ISSN (8-digit code), ISBN (13- or 10-digit code), or OCLC number. (e.g.  0040-781X; 0747581088; 921446069)"
+    "tip": "Search by ISSN (8-digit code), ISBN (13- or 10-digit code), or OCLC number (e.g.  0040-781X; 0747581088; 921446069)."
   },
   {
     "label": "Browse by call number (LC and Dewey) [BETA]",
     "value": "browse_by_callnumber",
-    "tip": "Browse by Library of Congress (LC) and Dewey call numbers, sorted alphanumerically. Learn about the meaning of call numbers. (e.g. RC662.4 .H38 2016; QH 105) <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
+    "tip": "Browse by Library of Congress (LC) and Dewey call numbers, sorted alphanumerically. Learn about the meaning of call numbers (e.g. RC662.4 .H38 2016; QH 105). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
     "selected": "selected"
   },
   {
     "label": "Browse by author (coming soon)",
     "value": "browse_by_author",
-    "tip": "Browse an alphabetical list of authors. Authors can be people (put last names first), organizations, or events. (e.g. Kingston, Maxine Hong; United Nations Development Programme; Pong, Chun-ho)",
+    "tip": "Browse an alphabetical list of authors. Authors can be people (put last names first), organizations, or events (e.g. Kingston, Maxine Hong; United Nations Development Programme; Pong, Chun-ho).",
     "disabled": "disabled"
   },
   {
     "label": "Browse by subject (coming soon)",
     "value": "browse_by_subject",
-    "tip": "Browse an A-Z list of subjects. (e.g. motion pictures; history--United States; Eliot, George)",
+    "tip": "Browse an A-Z list of subjects (e.g. motion pictures; history--United States; Eliot, George).",
     "disabled": "disabled"
   },
   {
     "label": "Browse by title (coming soon)",
     "value": "browse_by_title",
-    "tip": "Browse an alphabetical list of titles for books, online journals, serials, media, etc. (Nine stories; Tom Swift and )",
+    "tip": "Browse an alphabetical list of titles for books, online journals, serials, media, etc (e.g. Nine stories; Tom Swift).",
     "disabled": "disabled"
   }
 ];


### PR DESCRIPTION
# Overview
The tips contained some typos, mainly based on period placements.

This pull request resolves [SEARCH-1564](https://tools.lib.umich.edu/jira/browse/SEARCH-1564).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- On [localhost](http://localhost:3000/catalog?library=All+libraries), check the tip under the search form.
  - Does the tip for the default selected option appear on load?
  - When you select a different option, does the tip change?
  - Does the tip change when you try to select a disabled option?