### PR TITLE
[SEARCH-1571] Add tracking for search dropdown menu

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,6 +38,14 @@
       })(window, document, "script", "dataLayer", "GTM-5KZ8T2S");
     </script>
     <!-- End Google Tag Manager -->
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-1341620-18"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-1341620-18');
+    </script>
     <!-- Hotjar Tracking Code -->
     <script>
       (function (h, o, t, j, a, r) {

--- a/src/modules/core/components/Footer/index.js
+++ b/src/modules/core/components/Footer/index.js
@@ -37,33 +37,18 @@ const Footer = () => {
           {footer_links.map((item, i) => (
             <li key={i}>
               {item.to ? (
-                <Link
-                  to={item.to}
-                  data-ga-action="Click"
-                  data-ga-category="Footer"
-                  data-ga-label={item.text}
-                >
+                <Link to={item.to}>
                   {item.text}
                 </Link>
               ) : (
-                <a
-                  href={item.href}
-                  data-ga-action="Click"
-                  data-ga-category="Footer"
-                  data-ga-label={item.text}
-                >
+                <a href={item.href}>
                   {item.text}
                 </a>
               )}
             </li>
           ))}
           <li>
-            <a
-              href="https://ill.lib.umich.edu/"
-              data-ga-action="Click"
-              data-ga-category="Footer"
-              data-ga-label="Make an I.L.L. Request"
-            >
+            <a href="https://ill.lib.umich.edu/">
               Make an <abbr title="Interlibrary Loan">I.L.L.</abbr> Request
             </a>
           </li>

--- a/src/modules/core/components/SearchHeader/index.js
+++ b/src/modules/core/components/SearchHeader/index.js
@@ -54,13 +54,14 @@ function SearchHeader(props) {
           }
         }
       }}>
-        {navItems.map(n => (
+        {navItems.map((n, i) => (
           <a
             href={n.href}
             css={{ color: 'white', '&:hover': { textDecoration: 'underline' } }}
             data-ga-action="Click"
             data-ga-category="Header"
             data-ga-label={n.text}
+            key={i}
           >
             {n.text}
           </a>

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -4,9 +4,9 @@ import React from 'react'
 import {
   COLORS,
   Button,
-  Icon,
   MEDIA_QUERIES
-} from '@umich-lib/core'
+} from '@umich-lib/core';
+import Icon from "../../../reusable/components/Icon";
 import { useSelector } from "react-redux";
 import qs from "qs";
 import { withRouter } from "react-router";
@@ -116,7 +116,7 @@ function SearchBox({ history, match, location }) {
             }}
             >
             <select
-              class="dropdown"
+              className="dropdown"
               onChange={e => setField(e.target.value)}
               css={{
                 all: 'unset',
@@ -139,18 +139,18 @@ function SearchBox({ history, match, location }) {
               {isCatalog ? (
                 <React.Fragment>
                   <optgroup label={`Search by`}>
-                    {fields.map(field => <option value={field.uid}>{field.name}</option>)}
+                    {fields.map(field => <option value={field.uid} key={field.uid}>{field.name}</option>)}
                   </optgroup>
                   <optgroup label={`Browse by`}>
-                    <option value='browse_by_callnumber'>Browse by call number (LC and Dewey) [BETA]</option>
-                    <option value='browse_by_author' disabled>Browse by author (coming soon)</option>
-                    <option value='browse_by_subject' disabled>Browse by subject (coming soon)</option>
-                    <option value='browse_by_title' disabled>Browse by title (coming soon)</option>
+                    <option value='browse_by_callnumber' key='browse_by_callnumber'>Browse by call number (LC and Dewey) [BETA]</option>
+                    <option value='browse_by_author' key='browse_by_author' disabled>Browse by author (coming soon)</option>
+                    <option value='browse_by_subject' key='browse_by_subject' disabled>Browse by subject (coming soon)</option>
+                    <option value='browse_by_title' key='browse_by_title' disabled>Browse by title (coming soon)</option>
                   </optgroup>
                 </React.Fragment>
               ) : (
                 <React.Fragment>
-                  {fields.map(field => <option value={field.uid}>{field.name}</option>)}
+                  {fields.map(field => <option value={field.uid} key={field.uid}>{field.name}</option>)}
                 </React.Fragment>
               )}
             </select>

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -25,6 +25,14 @@ function SearchBox({ history, match, location }) {
   const [field, setField] = React.useState(fields[0].uid)
   const isCatalog = activeDatastore.uid === 'mirlyn';
 
+  function setOption(target) {
+    window.dataLayer.push({
+      event: 'selectionMade',
+      selectedElement: target.options[target.selectedIndex]
+    });
+    return setField(target.value)
+  }
+
   function handleSubmitSearch(e) {
     e.preventDefault()
 
@@ -117,7 +125,7 @@ function SearchBox({ history, match, location }) {
             >
             <select
               className="dropdown"
-              onChange={e => setField(e.target.value)}
+              onChange={e => setOption(e.target)}
               css={{
                 all: 'unset',
                 background: COLORS.grey['100'],

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -106,12 +106,15 @@ function SearchBox({ history, match, location }) {
             gridTemplateColumns: '340px 1fr auto auto',
           }
         }}>
-          <div css={{
-            gridArea: 'dropdown',
-            marginTop: '0.75rem',
-            position: 'relative',
-            width: '100%',
-          }}>
+          <div 
+            className="search-box-dropdown" 
+            css={{
+              gridArea: 'dropdown',
+              marginTop: '0.75rem',
+              position: 'relative',
+              width: '100%',
+            }}
+            >
             <select
               class="dropdown"
               onChange={e => setField(e.target.value)}

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -122,7 +122,7 @@ function SearchBox({ history, match, location }) {
               position: 'relative',
               width: '100%',
             }}
-            >
+          >
             <select
               className="dropdown"
               onChange={e => setOption(e.target)}


### PR DESCRIPTION
# Overview
In an effort to expand Google Tag Manager (GTM) events, a custom event had to be created for whenever a user makes a change in the Search Box dropdown. 

This PR addresses [SEARCH-1571](https://tools.lib.umich.edu/jira/browse/SEARCH-1571).

## Anything Else?
### GTM Cleanup
In the future, the plan is to take all of the hardcoded GTM events and set them up in the admin for more available control, according to the [Event Tracking Documentation](https://docs.google.com/spreadsheets/d/1WPdSqGcTI98l5nMBgvuIm9jUYE0MPGl45JxHk4wqTRw/edit?usp=sharing). This PR converts the Footer events, as a start.

### React Cleanup
There were many warnings relating to React on the home page, so some fixes have been applied.

#### Keys
Children elements require a unique `key` attribute, so they have been added wherever they were missing.

#### Icon
The `Icon` component coming from `@umich-lib/core` was throwing an error about not having a defined `icon` (name). I changed the import to use the internal `Icon` component to resolve the issue, and also because the Design System plans to remove the `Icon` component in the future.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
  - [ ] Edge
- Run accessibility tests:
  - [ ] WAVE
  - [ ] ARC Toolkit
  - [ ] axe DevTools
