### PR TITLE
[SEARCH-1598] Add new language as a fixed element at the end of metadata display

### DIFF
--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -190,6 +190,7 @@ class FullRecord extends React.Component {
 
             <h2 className="full-record__record-info">Record info:</h2>
             <RecordMetadata record={record} />
+            <HarmfulLanguage datastore={datastore.slug} />
           </div>
 
           <section aria-labelledby="available-at">
@@ -227,6 +228,18 @@ class FullRecord extends React.Component {
       </div>
     );
   }
+}
+
+function HarmfulLanguage ({datastore}) {
+  // Check if in correct datastore
+  if (!['catalog', 'onlinejournals'].includes(datastore)) return (null);
+  return (
+    <p>University of Michigan Library acknowledges that the language and structure 
+      used in collection descriptions and metadata often uphold and perpetuate 
+      oppression and bias. Please use this <a href="https://docs.google.com/forms/d/e/1FAIpQLSfSJ7y-zqmbNQ6ssAhSmwB7vF-NyZR9nVwBICFI8dY5aP1-TA/viewform">metadata feedback form</a> to 
+      anonymously report harmful or offensive language in catalog records, 
+      finding aids, or elsewhere in our collections.</p>
+  );
 }
 
 function mapStateToProps(state) {

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -234,11 +234,12 @@ function HarmfulLanguage ({datastore}) {
   // Check if in correct datastore
   if (!['catalog', 'onlinejournals'].includes(datastore)) return (null);
   return (
-    <p>University of Michigan Library acknowledges that the language and structure 
-      used in collection descriptions and metadata often uphold and perpetuate 
-      oppression and bias. Please use this <a href="https://docs.google.com/forms/d/e/1FAIpQLSfSJ7y-zqmbNQ6ssAhSmwB7vF-NyZR9nVwBICFI8dY5aP1-TA/viewform">metadata feedback form</a> to 
-      anonymously report harmful or offensive language in catalog records, 
-      finding aids, or elsewhere in our collections.</p>
+    <p>The University of Michigan Library aims to describe library materials in a
+      way that respects the people and communities who create, use, and are
+      represented in our collections. Report harmful or offensive language in catalog
+      records, finding aids, or elsewhere in our collections anonymously through
+      our <a href="https://docs.google.com/forms/d/e/1FAIpQLSfSJ7y-zqmbNQ6ssAhSmwB7vF-NyZR9nVwBICFI8dY5aP1-TA/viewform">metadata feedback form</a>.
+      More information at <a href="https://www.lib.umich.edu/about-us/policies/remediation-harmful-language-library-metadata">Remediation of Harmful Language.</a></p>
   );
 }
 

--- a/src/modules/search/search-options.js
+++ b/src/modules/search/search-options.js
@@ -55,7 +55,7 @@ const searchOptions = [
     "tip": "Search by ISSN (8-digit code), ISBN (13- or 10-digit code), or OCLC number (e.g.  0040-781X; 0747581088; 921446069)."
   },
   {
-    "label": "Browse by call number (LC and Dewey) [BETA]",
+    "label": "Browse by call number (LC and Dewey)",
     "value": "browse_by_callnumber",
     "tip": "Browse by Library of Congress (LC) and Dewey call numbers, sorted alphanumerically. Learn about the meaning of call numbers (e.g. RC662.4 .H38 2016; QH 105). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
     "selected": "selected"


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [SEARCH-1598](https://tools.lib.umich.edu/jira/browse/SEARCH-1598).

The library has issued a [Statement on Remediation of Harmful Metadata](https://www.lib.umich.edu/about-us/policies/remediation-harmful-language-library-metadata) on the public website. 

DAAG has requested that we add a statement to Catalog and Online Journal records letting users know they can raise concerns.

### Type of change

- [x] Text/content fix (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Search for an item that shows up in each datastore and select a record.
- See if the harmful remediation only shows up if the record falls under `Catalog` or `Online Journals`.

### This has been tested on the following browser(s)

- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [x] WAVE
- [ ] Accessibility Insights
- [x] axe
- [x] Other

