### PR TITLE
[SEARCH-1627] Database advanced keyword searches not being parsed correctly

### DIFF
--- a/src/modules/advanced/components/AdvancedSearchForm/index.js
+++ b/src/modules/advanced/components/AdvancedSearchForm/index.js
@@ -73,7 +73,8 @@ class AdvancedSearchForm extends React.Component {
           if (memo.length > 0) {
             memo.push(booleanTypes[fieldedSearch.booleanType]);
           }
-          memo.push(`${fieldedSearch.field}:(${fieldedSearch.query})`);
+          const input = fieldedSearch.field === 'keyword' ? fieldedSearch.query : `${fieldedSearch.field}:(${fieldedSearch.query})`;
+          memo.push(input);
         }
 
         return memo;


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [SEARCH-1627](https://tools.lib.umich.edu/jira/browse/SEARCH-1627)

When doing a basic `Keyword` search, the input is strictly the original value. When searching any other field, the value gets wrapped in the query (e.g. `author:(...)`). But when doing an advanced `Keyword` search, the query returns `keyword:(...)` instead of the original value. The advanced search now checks to see if the `Keyword` field has been selected and will return just the value without the wrap. 

### Type of change

- [x] Bug fix (non-breaking change)

## How Has This Been Tested?

- Go to advanced search, and make a `Keyword` search.
- Check to see if the value returns as is and not `keyword:(...)`.
- Make an advanced search using any other field, and see that the value is wrapped.

### This has been tested on the following browser(s)

- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [x] WAVE
- [ ] Accessibility Insights
- [x] axe
- [x] Other