### PR TITLE
[SEARCH-1631] GTM Events: Brief View

### DIFF
--- a/src/modules/records/components/BentoboxList/index.js
+++ b/src/modules/records/components/BentoboxList/index.js
@@ -7,7 +7,6 @@ import { Icon } from '../../../core'
 import { getMultiSearchRecords } from '../../../pride'
 import RecordPreview from '../RecordPreview'
 import RecordPreviewPlaceholder from '../RecordPreviewPlaceholder'
-import ReactGA from 'react-ga'
 
 
 import {
@@ -69,13 +68,6 @@ const BentoHeading = ({
     <Link
       className="bentobox-heading-container"
       to={url}
-      onClick={() => {
-        ReactGA.event({
-          action: 'Click',
-          category: 'Brief View',
-          label: `All ${bentobox.name} Results header`
-        })
-      }}
     >
       <h2 className="bentobox-heading">{ bentobox.name }</h2>
       <BentoboxResultsNum bentobox={bentobox} search={search} totalResults={totalResults}/>
@@ -105,13 +97,6 @@ const BentoFooter = ({
     <Link
       className="bentobox-footer-container"
       to={url}
-      onClick={() => {
-        ReactGA.event({
-          action: 'Click',
-          category: 'Brief View',
-          label: `All ${bentobox.name} Results footer`
-        })
-      }}
     >
       <span>{footerText}</span><Icon name="arrow-forward" />
     </Link>

--- a/src/modules/records/components/RecordPreview/index.js
+++ b/src/modules/records/components/RecordPreview/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import ReactGA from "react-ga";
 import { Icon, INTENT_COLORS } from "@umich-lib/core";
 
 import { Icon as SearchIcon, TrimString } from "../../../core";
@@ -29,18 +28,9 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
           <Link
             to={recordTitleLink}
             className="record-title-link"
-            onClick={() => {
-              ReactGA.event({
-                action: "Click",
-                category: "Brief View",
-                label: `Full view from brief ${datastoreUid}`
-              });
-            }}
           >
             {[].concat(record.names).map((title, index) => (
-              <span key={index}>
-                <TrimString string={title} />
-              </span>
+              <TrimString key={index} string={title} />
             ))}
           </Link>
         ) : (
@@ -48,18 +38,9 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
             <a
               href={recordTitleLink}
               className="record-title-link"
-              onClick={() => {
-                ReactGA.event({
-                  action: "Click",
-                  category: "Brief View",
-                  label: `Full view from brief ${datastoreUid}`
-                });
-              }}
             >
               {[].concat(record.names).map((title, index) => (
-                <span key={index}>
-                  <TrimString string={title} />
-                </span>
+                <TrimString key={index} string={title} />
               ))}
             </a>
             <SearchIcon name="launch" />
@@ -97,9 +78,6 @@ const Footer = ({ record, datastoreUid }) => {
         <a
           className="record-preview-link"
           href={accessCell.href}
-          data-ga-action="Click"
-          data-ga-category="Brief View"
-          data-ga-label={`${datastoreUid} Item Access`}
         >
           {accessCell.text}
         </a>


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [SEARCH-1631](https://tools.lib.umich.edu/jira/browse/SEARCH-1631)

This pull request removed these GTM Events:

* All [Datastore (Mirlyn (*Used for Catalog), Articlesplus (*Used for Articles), Primo (*Used for Primo), Databases, Journals, Onlinejournals, Website (*Used for Guides and More)] Results header
* All [Datastore (Mirlyn (*Used for Catalog), Articlesplus (*Used for Articles), Primo (*Used for Primo), Databases, Journals, Onlinejournals, Website (*Used for Guides and More)] Results Footer
* Full View From Brief [Datastore (Mirlyn (*Used for Catalog), Articlesplus (*Used for Articles), Primo (*Used for Primo), Databases, Journals, Onlinejournals, Website (*Used for Guides and More)]
* [Datastore (Articlesplus (*Used for Articles), Primo (*Used for Catalog since Alma launched), Databases, Onlinejournals ] Item Access

### Type of change
- [x] Text/content fix (non-breaking change)

## How Has This Been Tested?

The tags and triggers have been tested in GTM Preview before updating.

### This has been tested on the following browser(s)

- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [ ] WAVE
- [ ] Accessibility Insights
- [ ] axe
- [ ] Other

