### PR TITLE
[SEARCH-1633] and [SEARCH-1644] GTM Events: Change Page and Page Change

### DIFF
--- a/src/modules/reusable/components/Pagination/Pagination.js
+++ b/src/modules/reusable/components/Pagination/Pagination.js
@@ -2,7 +2,6 @@ import React from 'react'
 import numeral from 'numeral'
 import './Pagination.css'
 import { Link } from 'react-router-dom'
-import ReactGA from 'react-ga'
 
 class Pagination extends React.Component {
   state = {
@@ -25,11 +24,6 @@ class Pagination extends React.Component {
 
     if (Number.isInteger(page) && page > 0 && page <= total) {
       onPageChange(page)
-      ReactGA.event({
-        action: 'Click',
-        category: 'Page Change',
-        label: `Page Number ${page}`
-      })
     }
   }
 
@@ -55,9 +49,6 @@ class Pagination extends React.Component {
             <Link
               to={toPreviousPage}
               className="underline"
-              data-ga-action="Click"
-              data-ga-category="Change Page"
-              data-ga-label="Previous Page"
             >Previous page</Link>
           )}
         </div>
@@ -79,9 +70,6 @@ class Pagination extends React.Component {
             <Link
               to={toNextPage}
               className="underline"
-              data-ga-action="Click"
-              data-ga-category="Change Page"
-              data-ga-label="Next Page"
             >Next page</Link>
           )}
         </div>


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [SEARCH-1633](https://tools.lib.umich.edu/jira/browse/SEARCH-1633), and [SEARCH-1644](https://tools.lib.umich.edu/jira/browse/SEARCH-1644).

This pull request removed these GTM Events:

* [(Previous, Next)] Page
* Page Number [page number from which a page change occurs in search results]

### Type of change
- [x] Text/content fix (non-breaking change)

## How Has This Been Tested?

The tags and triggers have been tested in GTM Preview before updating.

### This has been tested on the following browser(s)

- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [ ] WAVE
- [ ] Accessibility Insights
- [ ] axe
- [ ] Other