### PR TITLE
[SEARCH-1635] GTM Events: Datastore Navigation

### DIFF
--- a/src/modules/datastores/components/DatastoreNavigation/presenter.js
+++ b/src/modules/datastores/components/DatastoreNavigation/presenter.js
@@ -82,9 +82,6 @@ const DatastoreNavigationItem = ({
         onClick={() => history.push(url)}
         aria-pressed={active}
         className={classNames}
-        data-ga-action="Click"
-        data-ga-category="Datastore Navigation"
-        data-ga-label={datastore.name}
       >
           <React.Fragment>
             {datastore.isMultisearch && <Icon name="multi-result" />}


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [SEARCH-1635](https://tools.lib.umich.edu/jira/browse/SEARCH-1635).

This pull request removed these GTM Events:

* [Datastore (Everything, Catalog, Articles, Articles via Primo API, Articles via Summon API, Primo Articles, Summon Articles, Databases, Online Journals, Guides and More)] 

### Type of change
- [x] Text/content fix (non-breaking change)

## How Has This Been Tested?

The tags and triggers have been tested in GTM Preview before updating.

### This has been tested on the following browser(s)

- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [ ] WAVE
- [ ] Accessibility Insights
- [ ] axe
- [ ] Other