### PR TITLE
[SEARCH-1640] GTM Events: Item Request

### DIFF
--- a/src/modules/getthis/components/GetThisForm/index.js
+++ b/src/modules/getthis/components/GetThisForm/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { connect } from 'react-redux';
-import ReactGA from 'react-ga'
 import {
   getField,
   getFieldValue,
@@ -90,14 +89,8 @@ class GetThisForm extends React.Component {
   }
 
   handleSubmit = (event) => {
-    const { datastoreUid, recordId, form, label } = this.props;
-    const { loading, fields } = this.state
-
-    ReactGA.event({
-      action: 'Catalog Get This',
-      category: 'Item Request',
-      label: `Submit Get This ${label}`
-    })
+    const { datastoreUid, recordId, form } = this.props;
+    const { loading, fields } = this.state;
 
     // Submitted form is type ajax and not already loading.
     if (form.type === 'ajax' && !loading) {

--- a/src/modules/getthis/components/GetThisOption/index.js
+++ b/src/modules/getthis/components/GetThisOption/index.js
@@ -3,7 +3,6 @@ import GetThisFindIt from '../GetThisFindIt'
 import {
   GetThisForm
 } from '../../../getthis'
-import ReactGA from 'react-ga'
 
 const createMarkup = (html) => {
   return { __html: html };
@@ -11,19 +10,10 @@ const createMarkup = (html) => {
 
 function GetThisOption({ option }) {
   const detailsRef = useRef(null);
-  const onSummaryClick = () => {
-    // If <details> was not open, then the user selected to open it.
-    const userIntent = detailsRef.current.hasAttribute('open') ? 'Close' : 'Open'
-    ReactGA.event({
-      action: 'Get This Options',
-      category: 'Item Request',
-      label: `${option.label} -- ${userIntent}`
-    })
-  }
 
   return (
     <details className="get-this-option" ref={detailsRef}>
-      <summary className="get-this-option-summary" onClick={onSummaryClick}>
+      <summary className="get-this-option-summary">
         <h3 className="get-this-option-heading"><span className="get-this-option-heading-text">{option.label}</span><span className="get-this-option-subheading">{option.service_type && (<span> {option.service_type} </span>)}({option.duration})</span></h3>
       </summary>
 


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [SEARCH-1640](https://tools.lib.umich.edu/jira/browse/SEARCH-1640).

This pull request removed these GTM Events:

* [Get This option (Contactless Pickup, Request to Have a Small Portion Scanned (Document Deivery), Have it Delivered, Find It in the Library, Request a Copy From Another Library (Interlibrary Loan (I.L.L.)), Request That This Copy Be Returned, Full Text Available Online, Place a Future Reservation, Pick It Up at the Library (Library to Library), Request a Digital Copy (Interlibrary Loan (I.L.L.)), Contact Circulation, Request Cannot Be Placed] -- [Open or Closed (*user clicked on the accordion to open/close the option in the Get This page)]

### Type of change
- [x] Text/content fix (non-breaking change)

## How Has This Been Tested?

The tags and triggers have been tested in GTM Preview before updating.

### This has been tested on the following browser(s)

- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [ ] WAVE
- [ ] Accessibility Insights
- [ ] axe
- [ ] Other