### PR TITLE
[SEARCH-1642] GTM Events: Medium View

### DIFF
--- a/src/modules/records/components/Record/index.js
+++ b/src/modules/records/components/Record/index.js
@@ -8,7 +8,6 @@ import { RecommendedResource, RecordMetadata } from "../../../records";
 import { getDatastoreSlugByUid } from "../../../pride";
 import { getField, getFieldValue } from "../../utilities";
 import { AddToListButton, isInList } from "../../../lists";
-import ReactGA from "react-ga";
 import { FavoriteRecord, FavoriteTags } from "../../../favorites";
 import Zotero from "../Zotero";
 import {
@@ -58,13 +57,6 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
         <Link
           to={recordTitleLink}
           className="record-title-link"
-          onClick={() => {
-            ReactGA.event({
-              action: "Click",
-              category: "Medium View",
-              label: `Full view from medium ${datastoreUid}`
-            });
-          }}
         >
           {[].concat(record.names).map((title, index) => (
             <span key={index}>
@@ -77,13 +69,6 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
           <a
             href={recordTitleLink}
             className="record-title-link"
-            onClick={() => {
-              ReactGA.event({
-                action: "Click",
-                category: "Medium View",
-                label: `Full view from medium ${datastoreUid}`
-              });
-            }}
           >
             {[].concat(record.names).map((title, index) => (
               <span key={index}>


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [SEARCH-1642](https://tools.lib.umich.edu/jira/browse/SEARCH-1642).

This pull request removed these GTM Events:

* Full View From Medium [Datastore (Mirlyn (*Used for Catalog), Articlesplus (*Used for Articles), Primo (*Used for Primo), Databases, Journals, Onlinejournals, Website (*Used for Guides and More)] 

### Type of change
- [x] Text/content fix (non-breaking change)

## How Has This Been Tested?

The tags and triggers have been tested in GTM Preview before updating.

### This has been tested on the following browser(s)

- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [ ] WAVE
- [ ] Accessibility Insights
- [ ] axe
- [ ] Other