### PR TITLE
[SEARCH-1654] Add search hints to Articles pages

### DIFF
--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -25,6 +25,7 @@ function SearchBox({ history, match, location }) {
   const defaultField = fields[0].uid;
   const [field, setField] = React.useState(defaultField)
   const isCatalog = activeDatastore.uid === 'mirlyn';
+  const isArticles = activeDatastore.uid === 'primo';
 
   function setOption(e) {
     window.dataLayer.push({
@@ -234,7 +235,7 @@ function SearchBox({ history, match, location }) {
             </Link>
           )}
         </div>
-        {isCatalog &&
+        {(isCatalog || isArticles) &&
           <SearchTip field={field} />
         }
       </div>

--- a/src/modules/search/search-options.js
+++ b/src/modules/search/search-options.js
@@ -47,7 +47,12 @@ const searchOptions = [
   {
     "label": "Year of Publication",
     "value": "publication_date",
-    "tip": "Search by year (YYYY) (e.g. 2021, 1942)"
+    "tip": "Search by year (YYYY) (e.g. 2021; 1942)."
+  },
+  {
+    "label": "Date",
+    "value": "publication_date",
+    "tip": "Search by year (YYYY) (e.g. 2021; 1942)."
   },
   {
     "label": "ISBN/ISSN/OCLC/etc",
@@ -55,7 +60,17 @@ const searchOptions = [
     "tip": "Search by ISSN (8-digit code), ISBN (13- or 10-digit code), or OCLC number (e.g.  0040-781X; 0747581088; 921446069)."
   },
   {
-    "label": "Browse by call number (LC and Dewey) [BETA]",
+    "label": "ISSN",
+    "value": "issn",
+    "tip": "Search by ISSN (8-digit code) (e.g., 0040-781X)."
+  },
+  {
+    "label": "ISBN",
+    "value": "isbn",
+    "tip": "Search by ISBN (13 or 10-digit code) (e.g., 0747581088)."
+  },
+  {
+    "label": "Browse by call number (LC and Dewey)",
     "value": "browse_by_callnumber",
     "tip": "Browse by Library of Congress (LC) and Dewey call numbers, sorted alphanumerically. Learn about the meaning of call numbers (e.g. RC662.4 .H38 2016; QH 105). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
     "selected": "selected"


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [SEARCH-1654](https://tools.lib.umich.edu/jira/browse/SEARCH-1654)

Search tips was originally added to the `Catalog` datastore. Now it is to be added to the `Articles` datastore!


### Type of change

Please delete options that are not relevant.

- [x] Text/content fix (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Checked out [Articles](http://localhost:3000/articles) and selected each search option to make sure each appropriate tip shows up.

### This has been tested on the following browser(s)

- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [ ] WAVE
- [ ] Accessibility Insights
- [ ] axe
- [ ] Other

## Preview

Insert screen shot, video, or deploy preview link. Add captions for images.

