### PR TITLE
Update packages (March) - Part 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "axios": "^0.26.1",
         "citeproc": "^2.4.62",
         "classnames": "^2.3.1",
-        "clipboard-polyfill": "^2.7.0",
         "connected-react-router": "^6.9.2",
         "core-js": "^3.21.1",
         "deepcopy": "^0.6.3",
@@ -5848,11 +5847,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/clipboard-polyfill": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/clipboard-polyfill/-/clipboard-polyfill-2.8.6.tgz",
-      "integrity": "sha512-kz/1ov+PXsBpGnW9XJH3dLWdYj12FpXqO89Dngm/GRPoI36E/tnYs6N0YPTEhxM9WHAlFiN5eoyIVuv5nzKXvg=="
     },
     "node_modules/cliui": {
       "version": "5.0.0",
@@ -26898,11 +26892,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
-    },
-    "clipboard-polyfill": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/clipboard-polyfill/-/clipboard-polyfill-2.8.6.tgz",
-      "integrity": "sha512-kz/1ov+PXsBpGnW9XJH3dLWdYj12FpXqO89Dngm/GRPoI36E/tnYs6N0YPTEhxM9WHAlFiN5eoyIVuv5nzKXvg=="
     },
     "cliui": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "axios": "^0.26.1",
     "citeproc": "^2.4.62",
     "classnames": "^2.3.1",
-    "clipboard-polyfill": "^2.7.0",
     "connected-react-router": "^6.9.2",
     "core-js": "^3.21.1",
     "deepcopy": "^0.6.3",

--- a/src/modules/lists/components/CitationAction/index.js
+++ b/src/modules/lists/components/CitationAction/index.js
@@ -9,7 +9,6 @@ import {
   TabPanel,
   Button
 } from '@umich-lib/core'
-import * as clipboard from 'clipboard-polyfill';
 import { Modal } from '../../../reusable'
 import { cite } from '../../../citations'
 
@@ -27,7 +26,7 @@ class CitationArea extends React.Component {
           maxHeight: '40vh'
         }}
         className="y-spacing"
-        contenteditable="true"
+        contentEditable="true"
         {...this.props}
       />
     )
@@ -74,21 +73,6 @@ class CitationAction extends Component {
 
   handleOpenModal = () => {
     this.setState({ modalIsOpen: true })
-  }
-
-  handleCopyToClipboard = (id) => {
-    const citation = this.state[id]
-
-    var dt = new clipboard.DT();
-    dt.setData("text/plain", citation);
-    clipboard.write(dt);
-
-    this.props.setAlert({
-      intent: 'success',
-      text: 'Citation copied to clipboard!'
-    })
-    
-    this.handleCloseModal()
   }
 
   handleCitationsData = (chosenStyleID, data) => {
@@ -152,7 +136,7 @@ class CitationAction extends Component {
             </TabList>
 
             {citation_options.map(co => (
-              <TabPanel>
+              <TabPanel key={`${co.name}-panel`}>
                 {this.state[co.id] ? (
                   <div className="y-spacing">
                     <CitationArea

--- a/src/modules/lists/components/CitationAction/index.js
+++ b/src/modules/lists/components/CitationAction/index.js
@@ -12,7 +12,7 @@ import {
 import { Modal } from '../../../reusable'
 import { cite } from '../../../citations'
 
-class CitationArea extends React.Component {
+class CitationArea extends Component {
   render() {
     return (
       <div
@@ -110,6 +110,17 @@ class CitationAction extends Component {
     this.handleOpenModal();
   }
 
+  handleCopyToClipboard = (citation) => {
+    navigator.clipboard.writeText(citation)
+
+    this.handleCloseModal()
+
+    this.props.setAlert({
+      intent: 'success',
+      text: 'Citation copied to clipboard!'
+    })
+  }
+
   render() {
     return (
       <div style={{
@@ -145,11 +156,14 @@ class CitationAction extends Component {
                         __html: this.state[co.id]
                       }}
                     />
-
                     <Text
                       small
                       id={`${co.id}-disclaimer`}
                     >These citations are generated from a variety of data sources. Remember to check citation format and content for accuracy before including them in your work.</Text>
+                    <Button
+                      onClick={() => this.handleCopyToClipboard(this.state[co.id])}
+                      style={{ marginRight: '1rem' }}
+                    >Copy citation</Button>
                     <Button kind="secondary" onClick={this.handleCloseModal}>Close</Button>
                   </div>
                 ) : (

--- a/src/modules/lists/components/PermalinkAction/index.js
+++ b/src/modules/lists/components/PermalinkAction/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { Modal } from '../../../reusable'
 import { Button, Heading, COLORS, TextInput } from '@umich-lib/core'
-import * as clipboard from 'clipboard-polyfill';
 
 class CitationAction extends Component {
   state = {
@@ -30,10 +29,7 @@ class CitationAction extends Component {
   }
 
   handleCopy = () => {
-    var dt = new clipboard.DT();
-    dt.setData("text/plain", this.state.permalink);
-    clipboard.write(dt);
-
+    navigator.clipboard.writeText(this.state.permalink)
     this.handleCopied()
   }
 
@@ -43,8 +39,6 @@ class CitationAction extends Component {
       intent: 'success',
       text: 'Link copied!'
     })
-
-    this.props.onUsed()
   }
 
   render() {


### PR DESCRIPTION
# Overview
This pull request removes `clipboard-polyfill`, and replaces the function with `navigator.clipboard.writeText(...)`.

## Testing
- `npm run reinstall && npm start`
- Poke around [the site](http://localhost:3000/) and see if anything seems broken.
- Search for a Catalog item and see if you can copy a citation and/or link.

## Troubleshooting
If you load the site and it produces this error:
![Screen Shot 2022-03-30 at 3 06 10 PM](https://user-images.githubusercontent.com/27687379/160911686-77086207-4c6c-4b0a-92fc-757ebebb2005.png)
- Stop the browser view (`Ctrl + C`).
- `cd node_modules/pride`
- `nano pride.js`
- Replace all instances of `_underscore._.` with `_underscore.` and save.
- `npm install`
- `cd ../../`
- `npm start`