### PR TITLE
Update packages (March) - Part 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "search",
       "version": "0.0.0",
       "dependencies": {
-        "@emotion/core": "^10.0.35",
-        "@emotion/styled": "^10.0.27",
+        "@emotion/core": "^10.3.1",
+        "@emotion/styled": "^10.3.0",
         "@umich-lib/core": "^0.1.1",
         "citeproc": "^2.4.62",
         "classnames": "^2.3.1",
@@ -2244,9 +2244,9 @@
       }
     },
     "node_modules/@emotion/core": {
-      "version": "10.0.35",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.35.tgz",
-      "integrity": "sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -2254,6 +2254,9 @@
         "@emotion/serialize": "^0.11.15",
         "@emotion/sheet": "0.9.4",
         "@emotion/utils": "0.11.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
       }
     },
     "node_modules/@emotion/css": {
@@ -2302,23 +2305,31 @@
       "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
     },
     "node_modules/@emotion/styled": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
-      "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.3.0.tgz",
+      "integrity": "sha512-GgcUpXBBEU5ido+/p/mCT2/Xx+Oqmp9JzQRuC+a4lYM4i4LBBn/dWvc0rQ19N9ObA8/T4NWMrPNe79kMBDJqoQ==",
       "dependencies": {
-        "@emotion/styled-base": "^10.0.27",
+        "@emotion/styled-base": "^10.3.0",
         "babel-plugin-emotion": "^10.0.27"
+      },
+      "peerDependencies": {
+        "@emotion/core": "^10.0.27",
+        "react": ">=16.3.0"
       }
     },
     "node_modules/@emotion/styled-base": {
-      "version": "10.0.31",
-      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
-      "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.3.0.tgz",
+      "integrity": "sha512-PBRqsVKR7QRNkmfH78hTSSwHWcwDpecH9W6heujWAcyp2wdz/64PP73s7fWS1dIPm8/Exc8JAzYS8dEWXjv60w==",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "@emotion/is-prop-valid": "0.8.8",
         "@emotion/serialize": "^0.11.15",
         "@emotion/utils": "0.11.3"
+      },
+      "peerDependencies": {
+        "@emotion/core": "^10.0.28",
+        "react": ">=16.3.0"
       }
     },
     "node_modules/@emotion/stylis": {
@@ -19394,9 +19405,9 @@
       "dev": true
     },
     "node_modules/tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
@@ -23062,9 +23073,9 @@
       }
     },
     "@emotion/core": {
-      "version": "10.0.35",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.35.tgz",
-      "integrity": "sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -23120,18 +23131,18 @@
       "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
     },
     "@emotion/styled": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
-      "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.3.0.tgz",
+      "integrity": "sha512-GgcUpXBBEU5ido+/p/mCT2/Xx+Oqmp9JzQRuC+a4lYM4i4LBBn/dWvc0rQ19N9ObA8/T4NWMrPNe79kMBDJqoQ==",
       "requires": {
-        "@emotion/styled-base": "^10.0.27",
+        "@emotion/styled-base": "^10.3.0",
         "babel-plugin-emotion": "^10.0.27"
       }
     },
     "@emotion/styled-base": {
-      "version": "10.0.31",
-      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
-      "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.3.0.tgz",
+      "integrity": "sha512-PBRqsVKR7QRNkmfH78hTSSwHWcwDpecH9W6heujWAcyp2wdz/64PP73s7fWS1dIPm8/Exc8JAzYS8dEWXjv60w==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/is-prop-valid": "0.8.8",
@@ -37655,9 +37666,9 @@
       "dev": true
     },
     "tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "tiny-warning": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,9 @@
         "react-dom": "^16.13.1",
         "react-ga": "^3.3.0",
         "react-modal": "^3.14.4",
-        "react-redux": "^7.2.6",
+        "react-redux": "^7.2.8",
         "react-router-dom": "^4.3.1",
-        "redux": "^3.6.0",
+        "redux": "^4.1.2",
         "redux-devtools-extension": "^2.13.8",
         "regenerator-runtime": "^0.13.9",
         "underscore": "^1.13.2"
@@ -3168,14 +3168,6 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
-      }
-    },
-    "node_modules/@types/react-redux/node_modules/redux": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -12656,12 +12648,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -16637,9 +16625,9 @@
       }
     },
     "node_modules/react-redux": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
-      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -16649,7 +16637,7 @@
         "react-is": "^17.0.2"
       },
       "peerDependencies": {
-        "react": "^16.8.3 || ^17"
+        "react": "^16.8.3 || ^17 || ^18"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -16884,14 +16872,11 @@
       }
     },
     "node_modules/redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
       "dependencies": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/redux-devtools-extension": {
@@ -18995,14 +18980,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -23882,16 +23859,6 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
-      },
-      "dependencies": {
-        "redux": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-          "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
-          "requires": {
-            "@babel/runtime": "^7.9.2"
-          }
-        }
       }
     },
     "@types/stack-utils": {
@@ -31942,12 +31909,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -35326,9 +35289,9 @@
       }
     },
     "react-redux": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
-      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -35541,14 +35504,11 @@
       }
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "redux-devtools-extension": {
@@ -37370,11 +37330,6 @@
           }
         }
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "react-autosuggest": "^9.4.3",
         "react-cookie": "^4.1.1",
         "react-dom": "^16.13.1",
-        "react-ga": "^2.7.0",
+        "react-ga": "^3.3.0",
         "react-modal": "^3.14.4",
         "react-redux": "^7.2.6",
         "react-router-dom": "^4.3.1",
@@ -16600,9 +16600,13 @@
       "dev": true
     },
     "node_modules/react-ga": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
-      "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
+      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^15.6.2 || ^16.0 || ^17"
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -35295,9 +35299,10 @@
       "dev": true
     },
     "react-ga": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
-      "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
+      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "react-scripts": "^3.4.4"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.35",
-    "@emotion/styled": "^10.0.27",
+    "@emotion/core": "^10.3.1",
+    "@emotion/styled": "^10.3.0",
     "@umich-lib/core": "^0.1.1",
     "citeproc": "^2.4.62",
     "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "react-dom": "^16.13.1",
     "react-ga": "^3.3.0",
     "react-modal": "^3.14.4",
-    "react-redux": "^7.2.6",
+    "react-redux": "^7.2.8",
     "react-router-dom": "^4.3.1",
-    "redux": "^3.6.0",
+    "redux": "^4.1.2",
     "redux-devtools-extension": "^2.13.8",
     "regenerator-runtime": "^0.13.9",
     "underscore": "^1.13.2"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-autosuggest": "^9.4.3",
     "react-cookie": "^4.1.1",
     "react-dom": "^16.13.1",
-    "react-ga": "^2.7.0",
+    "react-ga": "^3.3.0",
     "react-modal": "^3.14.4",
     "react-redux": "^7.2.6",
     "react-router-dom": "^4.3.1",


### PR DESCRIPTION
# Overview
This pull request updates several React-related dependencies to the latest subversion of their current versions.

These dependencies have been upgraded to their latest versions:
- `react-ga`
- `redux` and `react-redux`

## Testing
- `npm run reinstall && npm start`
- Poke around [the site](http://localhost:3000/) and see if anything seems broken.