### PR TITLE
[LIBSEARCH-82] Update Call Number Browse hint

### DIFF
--- a/src/modules/search/search-options.js
+++ b/src/modules/search/search-options.js
@@ -72,7 +72,7 @@ const searchOptions = [
   {
     "label": "Browse by call number (LC and Dewey)",
     "value": "browse_by_callnumber",
-    "tip": "Browse by Library of Congress (LC) and Dewey call numbers, sorted alphanumerically. Learn about the meaning of call numbers (e.g. RC662.4 .H38 2016; QH 105). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
+    "tip": "Browse by Library of Congress (LC) or Dewey call number, sorted alphanumerically (e.g. RC662.4 .H38 2016; QH 105, 880 J375re). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
     "selected": "selected"
   },
   {


### PR DESCRIPTION
# Overview

This PR addresses [LIBSEARCH-82](https://mlit.atlassian.net/browse/LIBSEARCH-82).

> There's a redundant "Learn about the meaning of call numbers" in the hint displayed in Call Number Browse.

The tip has been updated to match what is seen on Catalog Browse.

### Type of change
- [x] Text/content fix (non-breaking change)

