### PR TITLE
[LIBSEARCH-99] Remove 'Location Has' button from Catalog Location Holdings+Show Available Location Details on Default

### DIFF
--- a/src/modules/resource-acccess/components/holder.js
+++ b/src/modules/resource-acccess/components/holder.js
@@ -44,14 +44,27 @@ export default function Holder({
             css={{
               color: COLORS.neutral["400"],
               display: "inline-block",
-              paddingBottom: SPACING["S"],
             }}
           >
             {captionLink.text}
           </a>
         </p>
       )}
-      <Notes notes={notes} />
+      {notes && (
+        <ul>
+          {notes.map((note, i) => (
+            <li
+              key={note + i}
+              css={{
+                paddingBottom: SPACING["XS"],
+                color: COLORS.neutral["300"],
+              }}
+            >
+              {note}
+            </li>
+          ))}
+        </ul>
+      )}
 
       {rows && (
         <Expandable>
@@ -96,53 +109,6 @@ export default function Holder({
         </Expandable>
       )}
     </div>
-  );
-}
-
-function Notes({ notes }) {
-  const [expanded, setExpanded] = useState(true);
-
-  if (!notes) {
-    return null;
-  }
-
-  return (
-    <React.Fragment>
-      <Button
-        kind="secondary"
-        small
-        aria-expanded={expanded}
-        onClick={() => setExpanded(!expanded)}
-        css={{
-          display: "flex",
-          alignItems: "center",
-          marginBottom: SPACING["S"],
-        }}
-      >
-        <span css={{ paddingRight: "0.25rem" }}>Location has:</span>
-        {expanded ? (
-          <Icon d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z" size={19} />
-        ) : (
-          <Icon d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z" size={19} />
-        )}
-      </Button>
-
-      {expanded && (
-        <ul>
-          {notes.map((note, i) => (
-            <li
-              key={note + i}
-              css={{
-                paddingBottom: SPACING["XS"],
-                color: COLORS.neutral["300"],
-              }}
-            >
-              {note}
-            </li>
-          ))}
-        </ul>
-      )}
-    </React.Fragment>
   );
 }
 


### PR DESCRIPTION
# Overview

This PR addresses [LIBSEARCH-99](https://mlit.atlassian.net/browse/LIBSEARCH-99).

The `Location has` button has been removed, and will simply display the information by default.

### Type of change
- [x] Text/content fix (non-breaking change)

### This has been tested on the following browser(s)

- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Opera