### PR TITLE
[LIBSEARCH-63] Implement updated title & statement of responsibility displays

### DIFF
--- a/src/modules/core/components/TrimString/index.js
+++ b/src/modules/core/components/TrimString/index.js
@@ -23,9 +23,7 @@ class TrimString extends React.Component {
     const { string } = this.props
 
     if (string.length < this.state.trimLength) {
-      return (
-        <span>{string}</span>
-      )
+      return string
     }
 
     let displayString = null
@@ -42,7 +40,7 @@ class TrimString extends React.Component {
     }
 
     return (
-      <span>
+      <span className="trim-string-expandable">
         <span className="trim-string-text">{displayString}</span>
         {this.props.expandable && (
           <button

--- a/src/modules/getthis/components/GetThisRecord/index.js
+++ b/src/modules/getthis/components/GetThisRecord/index.js
@@ -115,7 +115,7 @@ class GetThisRecord extends React.Component {
         <RecordFullFormats formats={record.formats} />
         <div className="record-container">
           <h1 className="full-record-title u-margin-bottom-none">
-            {[...record.names].map((title, index) => {
+            {[].concat(record.names).map((title, index) => {
               if(index > 0) {
                 return (
                   <span className="vernacular vernacular-record-title" key={index}>

--- a/src/modules/getthis/components/GetThisRecord/index.js
+++ b/src/modules/getthis/components/GetThisRecord/index.js
@@ -115,11 +115,18 @@ class GetThisRecord extends React.Component {
         <RecordFullFormats formats={record.formats} />
         <div className="record-container">
           <h1 className="full-record-title u-margin-bottom-none">
-            {[].concat(record.names).map((title, index) => (
-              <div key={index}>
-                <TrimString string={title} />
-              </div>
-            ))}
+            {[...record.names].map((title, index) => {
+              if(index > 0) {
+                return (
+                  <span className="vernacular vernacular-record-title" key={index}>
+                    <TrimString string={title} />
+                  </span>
+                )
+              }
+              return (
+                <TrimString string={title} key={index} />
+              )
+            })}
           </h1>
         </div>
 

--- a/src/modules/records/components/Record/index.js
+++ b/src/modules/records/components/Record/index.js
@@ -53,46 +53,37 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
       >
         {record.position + 1}.
       </span>
-      {datastoreUid !== "website" ? (
-        <Link
-          to={recordTitleLink}
-          className="record-title-link"
-        >
-          {[].concat(record.names).map((title, index) => {
-            if(index > 0) {
-              return (
-                <span className="vernacular vernacular-record-title" key={index}>
-                  <TrimString string={title} />
-                </span>
-              )
-            }
-            return (
-              <TrimString string={title} key={index} />
-            )
-          })}
-        </Link>
-      ) : (
-        <span>
-          <a
-            href={recordTitleLink}
-            className="record-title-link"
-          >
-            {[].concat(record.names).map((title, index) => {
-              if(index > 0) {
-                return (
-                  <span className="vernacular vernacular-record-title" key={index}>
-                    <TrimString string={title} />
-                  </span>
-                )
-              }
-              return (
-                <TrimString string={title} key={index} />
-              )
-            })}
-          </a>
-          <Icon name="launch" />
-        </span>
-      )}
+      {[].concat(record.names).map((title, index) => {
+        if(index > 0) {
+          return (
+            <span className="vernacular vernacular-record-title" key={index}>
+              <TrimString string={title} />
+            </span>
+          )
+        }
+        if (datastoreUid !== "website") {
+          return (
+            <Link
+              to={recordTitleLink}
+              className="record-title-link"
+              key={index}
+            >
+              <TrimString string={title} />
+            </Link>
+          )
+        }
+        return (
+          <span key={index}>
+            <a
+              href={recordTitleLink}
+              className="record-title-link"
+            >
+              <TrimString string={title} />
+            </a>
+            <Icon name="launch" />
+          </span>
+        )
+      })}
       <RecommendedResource record={record} />
     </h3>
   );

--- a/src/modules/records/components/Record/index.js
+++ b/src/modules/records/components/Record/index.js
@@ -58,7 +58,7 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
           to={recordTitleLink}
           className="record-title-link"
         >
-          {[...record.names].map((title, index) => {
+          {[].concat(record.names).map((title, index) => {
             if(index > 0) {
               return (
                 <span className="vernacular vernacular-record-title" key={index}>
@@ -77,7 +77,7 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
             href={recordTitleLink}
             className="record-title-link"
           >
-            {[...record.names].map((title, index) => {
+            {[].concat(record.names).map((title, index) => {
               if(index > 0) {
                 return (
                   <span className="vernacular vernacular-record-title" key={index}>

--- a/src/modules/records/components/Record/index.js
+++ b/src/modules/records/components/Record/index.js
@@ -58,11 +58,18 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
           to={recordTitleLink}
           className="record-title-link"
         >
-          {[].concat(record.names).map((title, index) => (
-            <span key={index}>
-              <TrimString string={title} />
-            </span>
-          ))}
+          {[...record.names].map((title, index) => {
+            if(index > 0) {
+              return (
+                <span className="vernacular vernacular-record-title" key={index}>
+                  <TrimString string={title} />
+                </span>
+              )
+            }
+            return (
+              <TrimString string={title} key={index} />
+            )
+          })}
         </Link>
       ) : (
         <span>
@@ -70,11 +77,18 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
             href={recordTitleLink}
             className="record-title-link"
           >
-            {[].concat(record.names).map((title, index) => (
-              <span key={index}>
-                <TrimString string={title} />
-              </span>
-            ))}
+            {[...record.names].map((title, index) => {
+              if(index > 0) {
+                return (
+                  <span className="vernacular vernacular-record-title" key={index}>
+                    <TrimString string={title} />
+                  </span>
+                )
+              }
+              return (
+                <TrimString string={title} key={index} />
+              )
+            })}
           </a>
           <Icon name="launch" />
         </span>

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -100,7 +100,7 @@ class FullRecord extends React.Component {
       // Set page title
 
       setDocumentTitle([
-        [].concat(record.names).join().slice(0, 120),
+        [...record.names].join().slice(0, 120),
         "Record",
         activeDatastore.name,
       ]);
@@ -172,11 +172,19 @@ class FullRecord extends React.Component {
           <div className="record-container">
             <div className="full-record-title-and-actions-container">
               <h1 className="full-record-title">
-                {[].concat(record.names).map((title, index) => (
-                  <span key={index}>
-                    <TrimString string={title} expandable={true} />
-                  </span>
-                ))}
+                {[...record.names].map((title, index) => {
+                  if(index > 0) {
+                    return (
+                      <span className="vernacular vernacular-record-title" key={index}>
+                        {index} 
+                        <TrimString string={title} expandable={true} />
+                      </span>
+                    )
+                  }
+                  return (
+                    <TrimString string={title} expandable={true} key={index} />
+                  )
+                })}
                 <RecommendedResource record={record} />
               </h1>
 

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -100,7 +100,7 @@ class FullRecord extends React.Component {
       // Set page title
 
       setDocumentTitle([
-        [...record.names].join().slice(0, 120),
+        [].concat(record.names).join().slice(0, 120),
         "Record",
         activeDatastore.name,
       ]);
@@ -172,7 +172,7 @@ class FullRecord extends React.Component {
           <div className="record-container">
             <div className="full-record-title-and-actions-container">
               <h1 className="full-record-title">
-                {[...record.names].map((title, index) => {
+                {[].concat(record.names).map((title, index) => {
                   if(index > 0) {
                     return (
                       <span className="vernacular vernacular-record-title" key={index}>

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -176,7 +176,6 @@ class FullRecord extends React.Component {
                   if(index > 0) {
                     return (
                       <span className="vernacular vernacular-record-title" key={index}>
-                        {index} 
                         <TrimString string={title} expandable={true} />
                       </span>
                     )

--- a/src/modules/records/components/RecordPreview/index.js
+++ b/src/modules/records/components/RecordPreview/index.js
@@ -29,9 +29,18 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
             to={recordTitleLink}
             className="record-title-link"
           >
-            {[].concat(record.names).map((title, index) => (
-              <TrimString key={index} string={title} />
-            ))}
+            {[...record.names].map((title, index) => {
+              if(index > 0) {
+                return (
+                  <span className="vernacular vernacular-record-title" key={index}>
+                    <TrimString string={title} />
+                  </span>
+                )
+              }
+              return (
+                <TrimString string={title} key={index} />
+              )
+            })}
           </Link>
         ) : (
           <span>
@@ -39,9 +48,18 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
               href={recordTitleLink}
               className="record-title-link"
             >
-              {[].concat(record.names).map((title, index) => (
-                <TrimString key={index} string={title} />
-              ))}
+              {[...record.names].map((title, index) => {
+                if(index > 0) {
+                  return (
+                    <span className="vernacular vernacular-record-title" key={index}>
+                      <TrimString string={title} />
+                    </span>
+                  )
+                }
+                return (
+                  <TrimString string={title} key={index} />
+                )
+              })}
             </a>
             <SearchIcon name="launch" />
           </span>

--- a/src/modules/records/components/RecordPreview/index.js
+++ b/src/modules/records/components/RecordPreview/index.js
@@ -24,46 +24,37 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
   return (
     <header>
       <h3 className="record-preview-heading">
-        {hasFullView ? (
-          <Link
-            to={recordTitleLink}
-            className="record-title-link"
-          >
-            {[].concat(record.names).map((title, index) => {
-              if(index > 0) {
-                return (
-                  <span className="vernacular vernacular-record-title" key={index}>
-                    <TrimString string={title} />
-                  </span>
-                )
-              }
-              return (
-                <TrimString string={title} key={index} />
-              )
-            })}
-          </Link>
-        ) : (
-          <span>
-            <a
-              href={recordTitleLink}
-              className="record-title-link"
-            >
-              {[].concat(record.names).map((title, index) => {
-                if(index > 0) {
-                  return (
-                    <span className="vernacular vernacular-record-title" key={index}>
-                      <TrimString string={title} />
-                    </span>
-                  )
-                }
-                return (
-                  <TrimString string={title} key={index} />
-                )
-              })}
-            </a>
-            <SearchIcon name="launch" />
-          </span>
-        )}
+        {[].concat(record.names).map((title, index) => {
+          if(index > 0) {
+            return (
+              <span className="vernacular vernacular-record-title" key={index}>
+                <TrimString string={title} />
+              </span>
+            )
+          }
+          if (hasFullView) {
+            return (
+              <Link
+                to={recordTitleLink}
+                className="record-title-link"
+                key={index}
+              >
+                <TrimString string={title} />
+              </Link>
+            )
+          }
+          return (
+            <span key={index}>
+              <a
+                href={recordTitleLink}
+                className="record-title-link"
+              >
+                <TrimString string={title} />
+              </a>
+              <SearchIcon name="launch" />
+            </span>
+          )
+        })}
         <RecommendedResource record={record} />
       </h3>
     </header>

--- a/src/modules/records/components/RecordPreview/index.js
+++ b/src/modules/records/components/RecordPreview/index.js
@@ -29,7 +29,7 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
             to={recordTitleLink}
             className="record-title-link"
           >
-            {[...record.names].map((title, index) => {
+            {[].concat(record.names).map((title, index) => {
               if(index > 0) {
                 return (
                   <span className="vernacular vernacular-record-title" key={index}>
@@ -48,7 +48,7 @@ const Header = ({ record, datastoreUid, searchQuery }) => {
               href={recordTitleLink}
               className="record-title-link"
             >
-              {[...record.names].map((title, index) => {
+              {[].concat(record.names).map((title, index) => {
                 if(index > 0) {
                   return (
                     <span className="vernacular vernacular-record-title" key={index}>

--- a/src/modules/resource-acccess/components/holder.js
+++ b/src/modules/resource-acccess/components/holder.js
@@ -1,11 +1,9 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import React, { useState } from "react";
+import React from "react";
 import Holding from "./holding";
 import { COLORS, SPACING } from "../../reusable/umich-lib-core-temp";
 import {
-  Icon,
-  Button,
   Expandable,
   ExpandableProvider,
   ExpandableChildren,

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -1051,6 +1051,14 @@ body {
     width: 0.85rem;
     color: #4E4E4E; }
 
+.vernacular {
+  color: #6e6e6e;
+}
+
+.vernacular-record-title {
+  display: block;
+}
+
 .record-title-link {
   border-bottom: solid 2px rgba(18, 109, 193, 0.4); }
   .record-title-link:hover {


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [LIBSEARCH-63](https://mlit.atlassian.net/browse/LIBSEARCH-63).

Vernacular information has been added to the record titles metadata. This PR separates and styles the information according to [Figma](https://www.figma.com/file/4izNI8OilJi1MXsNKiKWhX/Library-Search-Design-System?node-id=7%3A44).


### Type of change
- [x] Text/content fix (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)

### This has been tested on the following browser(s)

- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [x] WAVE
- [ ] Accessibility Insights
- [ ] axe
- [ ] Other

