### PR TITLE
[LIBSEARCH-197] Figure out the exact & contains menu structure and connect with the back end

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -205,6 +205,7 @@ const config = {
     primo: {
       fields: [
         "keyword",
+        "contains",
         "title",
         "author",
         "publication_title",

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -181,6 +181,7 @@ function SearchBox({ history, match, location }) {
             value={inputQuery}
             onChange={e => setInputQuery(e.target.value)}
             autoComplete="on"
+            name="query"
             css={{
               all: 'unset',
               background: 'white',

--- a/src/modules/search/search-options.js
+++ b/src/modules/search/search-options.js
@@ -2,12 +2,12 @@ const searchOptions = [
   {
     "label": "Keyword (is exact)",
     "value": "keyword",
-    "tip": "Enter an exact phrase to search (e.g., solar power). Use AND to separate concepts or phrases (e.g., Black Women Scientists AND Chanda Prescod). See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>.<br /><br />Using exact match will return results for records that contain only these exact keywords in the same metadata field of a record."
+    "tip": "Enter an exact phrase to search (e.g., solar power). Use AND to separate concepts or phrases (e.g., Black Women Scientists AND Chanda Prescod). See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>."
   },
   {
     "label": "Keyword (contains)",
     "value": "contains",
-    "tip": "Enter one or more keywords to search broadly. (e.g., Black Women Scientists) Use quotes to search for a specific phrase. (e.g., “systems of oppression”) See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>.<br /><br />Search will return results for all records that contain one or more of your keywords in the record's metadata. It also searches across all metadata fields. It will not consider which fields the keywords are located in."
+    "tip": "Enter one or more keywords to search broadly. (e.g., Black Women Scientists) Use quotes to search for a specific phrase. (e.g., “systems of oppression”) See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>."
   },
   {
     "label": "Title",

--- a/src/modules/search/search-options.js
+++ b/src/modules/search/search-options.js
@@ -1,101 +1,126 @@
 const searchOptions = [
   {
+    "label": "Keyword",
+    "value": "keyword",
+    "tip": "Enter one or more keywords. Use quotes to search for a phrase (e.g. solar power; polar bears; “systems of oppression”). See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>.",
+    "datastore": "mirlyn"
+  },
+  {
     "label": "Keyword (is exact)",
     "value": "keyword",
-    "tip": "Enter an exact phrase to search (e.g., solar power). Use AND to separate concepts or phrases (e.g., Black Women Scientists AND Chanda Prescod). See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>."
+    "tip": "Enter an exact phrase to search (e.g., solar power). Use AND to separate concepts or phrases (e.g., Black Women Scientists AND Chanda Prescod). See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>.",
+    "datastore": "primo"
   },
   {
     "label": "Keyword (contains)",
     "value": "contains",
-    "tip": "Enter one or more keywords to search broadly. (e.g., Black Women Scientists) Use quotes to search for a specific phrase. (e.g., “systems of oppression”) See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>."
+    "tip": "Enter one or more keywords to search broadly. (e.g., Black Women Scientists) Use quotes to search for a specific phrase. (e.g., “systems of oppression”) See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>.",
+    "datastore": "primo"
   },
   {
     "label": "Title",
     "value": "title",
-    "tip": "Enter the first words in a title. Use quotes to search a phrase (e.g. One Hundred Years of Solitude; “The Fourth World”; Disability Visibility)."
+    "tip": "Enter the first words in a title. Use quotes to search a phrase (e.g. One Hundred Years of Solitude; “The Fourth World”; Disability Visibility).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Title starts with",
     "value": "title_starts_with",
-    "tip": "Search for titles that begin with a word or phrase (e.g., introduction to chemistry; history of Mexico; Asian art)."
+    "tip": "Search for titles that begin with a word or phrase (e.g., introduction to chemistry; history of Mexico; Asian art).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Author",
     "value": "author",
-    "tip": "Search for items by author or contributor. Also search organizations or corporate authors (e.g. Kimmerer, Robin Wall; American Medical Association; 小川 洋子)."
+    "tip": "Search for items by author or contributor. Also search organizations or corporate authors (e.g. Kimmerer, Robin Wall; American Medical Association; 小川 洋子).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Journal/Serial Title",
     "value": "journal_title",
-    "tip": "Search the title of a journal or serial publication (e.g. Detroit Free Press; “journal of the american medical association”; African-American newspapers)."
+    "tip": "Search the title of a journal or serial publication (e.g. Detroit Free Press; “journal of the american medical association”; African-American newspapers).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Subject",
     "value": "subject",
-    "tip": "Use words or phrases to search subject headings (e.g., public health; radicalism--united states; Baldwin, James)."
+    "tip": "Use words or phrases to search subject headings (e.g., public health; radicalism--united states; Baldwin, James).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Academic Discipline",
     "value": "academic_discipline",
-    "tip": "Search academic disciplines. <a href=\"https://search.lib.umich.edu/databases/browse?query=sculpture\">Browse all Databases</a> alphabetically or by academic discipline (e.g. International business; Latin american and caribbean studies)."
+    "tip": "Search academic disciplines. <a href=\"https://search.lib.umich.edu/databases/browse?query=sculpture\">Browse all Databases</a> alphabetically or by academic discipline (e.g. International business; Latin american and caribbean studies).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Call Number starts with",
     "value": "call_number_starts_with",
-    "tip": "Search the first few letters and numbers of a call number (e.g. RC662.4 .H38 2016; QH 105). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>."
+    "tip": "Search the first few letters and numbers of a call number (e.g. RC662.4 .H38 2016; QH 105). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Series (transcribed)",
     "value": "series",
-    "tip": "Search the series title of a group of thematically-related books. Use ‘title’ search to find unique titles within a series (e.g., Politics of Race and Ethnicity, Brill's Annotated Bibliographies, Oxford Choral Music)."
+    "tip": "Search the series title of a group of thematically-related books. Use ‘title’ search to find unique titles within a series (e.g., Politics of Race and Ethnicity, Brill's Annotated Bibliographies, Oxford Choral Music).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Year of Publication",
     "value": "publication_date",
-    "tip": "Search by year (YYYY) (e.g. 2021; 1942)."
+    "tip": "Search by year (YYYY) (e.g. 2021; 1942).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Date",
     "value": "publication_date",
-    "tip": "Search by year (YYYY) (e.g. 2021; 1942)."
+    "tip": "Search by year (YYYY) (e.g. 2021; 1942).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "ISBN/ISSN/OCLC/etc",
     "value": "isn",
-    "tip": "Search by ISSN (8-digit code), ISBN (13- or 10-digit code), or OCLC number (e.g.  0040-781X; 0747581088; 921446069)."
+    "tip": "Search by ISSN (8-digit code), ISBN (13- or 10-digit code), or OCLC number (e.g.  0040-781X; 0747581088; 921446069).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "ISSN",
     "value": "issn",
-    "tip": "Search by ISSN (8-digit code) (e.g., 0040-781X)."
+    "tip": "Search by ISSN (8-digit code) (e.g., 0040-781X).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "ISBN",
     "value": "isbn",
-    "tip": "Search by ISBN (13 or 10-digit code) (e.g., 0747581088)."
+    "tip": "Search by ISBN (13 or 10-digit code) (e.g., 0747581088).",
+    "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Browse by call number (LC and Dewey)",
     "value": "browse_by_callnumber",
     "tip": "Browse by Library of Congress (LC) or Dewey call number, sorted alphanumerically (e.g. RC662.4 .H38 2016; QH 105, 880 J375re). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
+    "datastore": "mirlyn",
     "selected": "selected"
   },
   {
     "label": "Browse by author (coming soon)",
     "value": "browse_by_author",
     "tip": "Browse an alphabetical list of authors. Authors can be people (put last names first), organizations, or events (e.g. Kingston, Maxine Hong; United Nations Development Programme; Pong, Chun-ho).",
+    "datastore": "mirlyn",
     "disabled": "disabled"
   },
   {
     "label": "Browse by subject (coming soon)",
     "value": "browse_by_subject",
     "tip": "Browse an A-Z list of subjects (e.g. motion pictures; history--United States; Eliot, George).",
+    "datastore": "mirlyn",
     "disabled": "disabled"
   },
   {
     "label": "Browse by title (coming soon)",
     "value": "browse_by_title",
     "tip": "Browse an alphabetical list of titles for books, online journals, serials, media, etc (e.g. Nine stories; Tom Swift).",
+    "datastore": "mirlyn",
     "disabled": "disabled"
   }
 ];

--- a/src/modules/search/search-options.js
+++ b/src/modules/search/search-options.js
@@ -1,8 +1,13 @@
 const searchOptions = [
   {
-    "label": "Keyword",
+    "label": "Keyword (is exact)",
     "value": "keyword",
-    "tip": "Enter one or more keywords. Use quotes to search for a phrase (e.g. solar power; polar bears; “systems of oppression”). See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>."
+    "tip": "Enter an exact phrase to search (e.g., solar power). Use AND to separate concepts or phrases (e.g., Black Women Scientists AND Chanda Prescod). See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>.<br /><br />Using exact match will return results for records that contain only these exact keywords in the same metadata field of a record."
+  },
+  {
+    "label": "Keyword (contains)",
+    "value": "contains",
+    "tip": "Enter one or more keywords to search broadly. (e.g., Black Women Scientists) Use quotes to search for a specific phrase. (e.g., “systems of oppression”) See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>.<br /><br />Search will return results for all records that contain one or more of your keywords in the record's metadata. It also searches across all metadata fields. It will not consider which fields the keywords are located in."
   },
   {
     "label": "Title",

--- a/src/modules/search/search-options.js
+++ b/src/modules/search/search-options.js
@@ -20,108 +20,96 @@ const searchOptions = [
   {
     "label": "Title",
     "value": "title",
-    "tip": "Enter the first words in a title. Use quotes to search a phrase (e.g. One Hundred Years of Solitude; “The Fourth World”; Disability Visibility).",
+    "tip": "Enter the first words in an article title. Use quotes to search for a phrase. (e.g., Culture as disability).",
     "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Title starts with",
     "value": "title_starts_with",
     "tip": "Search for titles that begin with a word or phrase (e.g., introduction to chemistry; history of Mexico; Asian art).",
-    "datastore": ["mirlyn", "primo"]
+    "datastore": "mirlyn"
   },
   {
     "label": "Author",
     "value": "author",
-    "tip": "Search for items by author or contributor. Also search organizations or corporate authors (e.g. Kimmerer, Robin Wall; American Medical Association; 小川 洋子).",
+    "tip": "Search for items by author or contributor. (e.g., Kimmerer, Robin Wall) Also search organizations or corporate authors. (e.g., American Medical Association). Search for items by author using original scripts (e.g. 小川 洋子)",
     "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Journal/Serial Title",
     "value": "journal_title",
     "tip": "Search the title of a journal or serial publication (e.g. Detroit Free Press; “journal of the american medical association”; African-American newspapers).",
-    "datastore": ["mirlyn", "primo"]
+    "datastore": "mirlyn"
   },
   {
-    "label": "Subject",
+    "label": "Subject contains",
     "value": "subject",
-    "tip": "Use words or phrases to search subject headings (e.g., public health; radicalism--united states; Baldwin, James).",
-    "datastore": ["mirlyn", "primo"]
-  },
-  {
-    "label": "Academic Discipline",
-    "value": "academic_discipline",
-    "tip": "Search academic disciplines. <a href=\"https://search.lib.umich.edu/databases/browse?query=sculpture\">Browse all Databases</a> alphabetically or by academic discipline (e.g. International business; Latin american and caribbean studies).",
+    "tip": "Use words or phrases to search subjects. (e.g., plant physiology; Baldwin, James)",
     "datastore": ["mirlyn", "primo"]
   },
   {
     "label": "Call Number starts with",
     "value": "call_number_starts_with",
     "tip": "Search the first few letters and numbers of a call number (e.g. RC662.4 .H38 2016; QH 105). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
-    "datastore": ["mirlyn", "primo"]
+    "datastore": "mirlyn"
   },
   {
-    "label": "Series (transcribed)",
+    "label": "Series title",
     "value": "series",
     "tip": "Search the series title of a group of thematically-related books. Use ‘title’ search to find unique titles within a series (e.g., Politics of Race and Ethnicity, Brill's Annotated Bibliographies, Oxford Choral Music).",
-    "datastore": ["mirlyn", "primo"]
-  },
-  {
-    "label": "Year of Publication",
-    "value": "publication_date",
-    "tip": "Search by year (YYYY) (e.g. 2021; 1942).",
-    "datastore": ["mirlyn", "primo"]
+    "datastore": "mirlyn"
   },
   {
     "label": "Date",
     "value": "publication_date",
     "tip": "Search by year (YYYY) (e.g. 2021; 1942).",
-    "datastore": ["mirlyn", "primo"]
+    "datastore": "primo"
   },
   {
     "label": "ISBN/ISSN/OCLC/etc",
     "value": "isn",
     "tip": "Search by ISSN (8-digit code), ISBN (13- or 10-digit code), or OCLC number (e.g.  0040-781X; 0747581088; 921446069).",
-    "datastore": ["mirlyn", "primo"]
+    "datastore": "mirlyn"
   },
   {
     "label": "ISSN",
     "value": "issn",
     "tip": "Search by ISSN (8-digit code) (e.g., 0040-781X).",
-    "datastore": ["mirlyn", "primo"]
+    "datastore": "primo"
   },
   {
     "label": "ISBN",
     "value": "isbn",
     "tip": "Search by ISBN (13 or 10-digit code) (e.g., 0747581088).",
-    "datastore": ["mirlyn", "primo"]
+    "datastore": "primo"
   },
   {
     "label": "Browse by call number (LC and Dewey)",
     "value": "browse_by_callnumber",
     "tip": "Browse by Library of Congress (LC) or Dewey call number, sorted alphanumerically (e.g. RC662.4 .H38 2016; QH 105, 880 J375re). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
-    "datastore": "mirlyn",
-    "selected": "selected"
+    "selected": "selected",
+    "datastore": "mirlyn"
   },
   {
-    "label": "Browse by author (coming soon)",
+    "label": "Browse by author",
     "value": "browse_by_author",
     "tip": "Browse an alphabetical list of authors. Authors can be people (put last names first), organizations, or events (e.g. Kingston, Maxine Hong; United Nations Development Programme; Pong, Chun-ho).",
-    "datastore": "mirlyn",
-    "disabled": "disabled"
+    "disabled": "disabled",
+    "datastore": "mirlyn"
   },
   {
-    "label": "Browse by subject (coming soon)",
+    "label": "Browse by subject",
     "value": "browse_by_subject",
     "tip": "Browse an A-Z list of subjects (e.g. motion pictures; history--United States; Eliot, George).",
-    "datastore": "mirlyn",
-    "disabled": "disabled"
+    "disabled": "disabled",
+    "datastore": "mirlyn"
   },
   {
-    "label": "Browse by title (coming soon)",
+    "label": "Browse by title",
     "value": "browse_by_title",
     "tip": "Browse an alphabetical list of titles for books, online journals, serials, media, etc (e.g. Nine stories; Tom Swift).",
-    "datastore": "mirlyn",
-    "disabled": "disabled"
+    "disabled": "disabled",
+    "datastore": "mirlyn"
   }
 ];
 

--- a/src/modules/search/search-options.js
+++ b/src/modules/search/search-options.js
@@ -91,21 +91,21 @@ const searchOptions = [
     "datastore": "mirlyn"
   },
   {
-    "label": "Browse by author",
+    "label": "Browse by author (coming soon)",
     "value": "browse_by_author",
     "tip": "Browse an alphabetical list of authors. Authors can be people (put last names first), organizations, or events (e.g. Kingston, Maxine Hong; United Nations Development Programme; Pong, Chun-ho).",
     "disabled": "disabled",
     "datastore": "mirlyn"
   },
   {
-    "label": "Browse by subject",
+    "label": "Browse by subject (coming soon)",
     "value": "browse_by_subject",
     "tip": "Browse an A-Z list of subjects (e.g. motion pictures; history--United States; Eliot, George).",
     "disabled": "disabled",
     "datastore": "mirlyn"
   },
   {
-    "label": "Browse by title",
+    "label": "Browse by title (coming soon)",
     "value": "browse_by_title",
     "tip": "Browse an alphabetical list of titles for books, online journals, serials, media, etc (e.g. Nine stories; Tom Swift).",
     "disabled": "disabled",


### PR DESCRIPTION
# Overview

When searching Articles by `keyword`, it searches by `exact` results. There is now an option to search for keywords it `contains`. Instead of now just having `Keyword` listed in the `select` menu, it has been replaced with two new options:
* `Keyword (is exact)`
* `Keyword (contains)`

This pull request closes [LIBSEARCH-197](https://mlit.atlassian.net/browse/LIBSEARCH-197).

## Anything else?
`autocomplete="on"` has already existed on the search box's `input[type="text"]` element, which would show previously searched values. However, it was not trigger due to a lack of the `name` attribute. The attribute has been added to fix this issue.

This pull request resolves [LIBSEARCH-712](https://mlit.atlassian.net/browse/LIBSEARCH-712).