### PR TITLE
[LIBSEARCH-710] Remove Filters from Landing Pages (on mobile)

### DIFF
--- a/src/modules/pages/components/DatastorePage/container.js
+++ b/src/modules/pages/components/DatastorePage/container.js
@@ -192,9 +192,10 @@ const Results = ({ activeDatastore, activeFilterCount }) => {
   }
 
   const hasActiveFilters = activeFilterCount > 0;
-  const summaryClassName = hasActiveFilters
-    ? "small-screen-filter-summary small-screen-filter-summary--active-filters"
-    : "small-screen-filter-summary";
+  let summaryClassName = 'small-screen-filter-summary';
+  if (hasActiveFilters) {
+    summaryClassName += ' small-screen-filter-summary--active-filters';
+  }
 
   return (
     <div


### PR DESCRIPTION
# Overview
`Filters` has a dropdown option when viewing on mobile. It was appearing on datastore landing pages, when no search was active.

![Screen Shot 2022-05-23 at 11 48 21 AM](https://user-images.githubusercontent.com/27687379/169857958-0cd0b993-0f39-46ad-b468-be42653cc552.png)

This dropdown now only shows if `searching` is active. The overall logic of the component has also been simplified.

This pull request closes [LIBSEARCH-710](https://mlit.atlassian.net/browse/LIBSEARCH-710).