### PR TITLE
[LIBSEARCH-728] Add Google Analytics 4 with GTM Tracking Code to U-M Library Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,52 +6,83 @@ This repository contains the front-end code that generates the UI and connects t
 
 ### 1. Clone Search
 
-```sh
+```bash
 $ git clone https://github.com/mlibrary/search.git
 ```
 
 ### 2. Install
 
-```sh
+```bash
 $ npm install
 ```
 
 ### 3. Run Locally
 
-```sh
+```bash
 $ npm start
 ```
 
 ### Troubleshooting
+#### TypeError: Cannot read properties of undefined (reading 'isFunction')
 If you load the site and it produces this error:
 
 ![Screen Shot 2022-03-30 at 3 06 10 PM](https://user-images.githubusercontent.com/27687379/160911686-77086207-4c6c-4b0a-92fc-757ebebb2005.png)
 
-#### 1. Stop the browser view (`Ctrl + C`)
+##### 1. Stop the browser view (`Ctrl + C`)
 
-#### 2. Navigate to the `pride` dependency
+##### 2. Navigate to the `pride` dependency
 
-```sh
+```bash
 $ cd node_modules/pride
 ```
 
-#### 3. Edit `pride.js`
+##### 3. Edit `pride.js`
 
-```sh
+```bash
 $ nano pride.js
 ```
-#### 4. Replace all instances of `_underscore._.` with `_underscore.` and save.
+##### 4. Replace all instances of `_underscore._.` with `_underscore.` and save.
 
-#### 5. Install `pride`
+##### 5. Install `pride`
 
-```sh
+```bash
 $ npm install
 ```
 
-#### 6. Go back and rerun the app
+##### 6. Go back and rerun the app
 
-```sh
+```bash
 $ cd ../../ && npm start
+```
+
+#### ERR_OSSL_EVP_UNSUPPORTED
+If you run `npm start` and receive this error:
+```bash
+Error: error:0308010C:digital envelope routines::unsupported
+ opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
+  library: 'digital envelope routines',
+  reason: 'unsupported',
+  code: 'ERR_OSSL_EVP_UNSUPPORTED'
+```
+
+##### 1. Check current version of Node
+
+```bash
+node --version
+```
+
+If the version of Node is higher than `17`, follow the next step.
+
+##### 2. Export NODE_OPTIONS
+
+```bash
+export NODE_OPTIONS=--openssl-legacy-provider
+```
+
+##### 3. Run the app
+
+```bash
+npm start
 ```
 
 ## CSS

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   },
   "scripts": {
     "reinstall": "rm -rf node_modules && npm install",
-    "start": "REACT_APP_SPECTRUM_BASE_URL=${REACT_APP_SPECTRUM_BASE_URL:-https://search-staging.www.lib.umich.edu/spectrum} react-scripts --openssl-legacy-provider start",
+    "start": "REACT_APP_SPECTRUM_BASE_URL=${REACT_APP_SPECTRUM_BASE_URL:-https://search-staging.www.lib.umich.edu/spectrum} react-scripts start",
     "develop": "npm run start",
-    "build": "react-scripts --openssl-legacy-provider build",
+    "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
# LIBSEARCH-728

This PR addresses [LIBSEARCH-728](https://mlit.atlassian.net/browse/LIBSEARCH-728).

Google will be retiring Universal Analytics in 2023, forcing users to switch to Google Analytics 4. This pull request adds the script in parallel with the current one for applying and testing. When the GA4 version is officially set up, the UA script will be removed.

## `ERR_OSSL_EVP_UNSUPPORTED`
When running NodeJS 17+, you may run into the error `ERR_OSSL_EVP_UNSUPPORTED`. According to [bswen](https://www.bswen.com/2021/11/reactjs-ERR_OSSL_EVP_UNSUPPORTED_error_solution.html), `--openssl-legacy-provider` needs to be set as a `NODE_OPTION`. Instructions on how to do this has been added to the `README`.