### PR TITLE
Replacing colors with what was in `@umich/styles`

### DIFF
--- a/src/modules/reusable/umich-lib-core-temp/index.js
+++ b/src/modules/reusable/umich-lib-core-temp/index.js
@@ -197,10 +197,10 @@ export const LINK_COLOR = COLORS.teal[400];
 export const FONT_COLOR = COLORS.blue[500];
 
 export const INTENT_COLORS = {
-  informational: COLORS.blue[400],
+  informational: SEARCH_COLORS.blue[400],
   success: SEARCH_COLORS.green[600],
-  warning: COLORS.maize[400],
-  error: SEARCH_COLORS.orange[400]
+  warning: SEARCH_COLORS.orange[600],
+  error: SEARCH_COLORS.red[600]
 };
 
 export function GlobalStyleSheet() {


### PR DESCRIPTION
`warning` was showing as an inaccessible shade of yellow. The colors have been replaced with what was originally used in the `@umich/styles` package.