### PR TITLE
[LIBSEARCH-759] Search hints in Catalog are not displaying a recent Search release

### DIFF
--- a/src/modules/search/components/SearchTip/index.js
+++ b/src/modules/search/components/SearchTip/index.js
@@ -5,7 +5,7 @@ import { searchOptions, searchOptionsDatastores } from '../../utilities';
 const SearchTip = ({activeDatastore, field}) => {
   // Check if current datastore is found in any of the search options
   if (!searchOptionsDatastores().includes(activeDatastore.uid)) return (null);
-  const selectOption = searchOptions().find((searchOption) => searchOption.datastore.includes(activeDatastore.uid) && searchOption.value === field);
+  const selectOption = searchOptions().find((searchOption) => searchOption.datastore.includes(activeDatastore.uid) && searchOption.uid === field);
   // Check if option and tip exist
   if (selectOption === undefined || selectOption.tip === undefined) return (null);
   return (


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [LIBSEARCH-759](https://mlit.atlassian.net/browse/LIBSEARCH-759)

`SearchTip` stopped showing up on Search. This was because the `tip` property needed to be updated to `uid`.


### Type of change

- [x] Bug fix (non-breaking change)