### PR TITLE
For a specified search use the value directly without prepending a fi…

### DIFF
--- a/src/modules/reusable/components/Metadata/index.js
+++ b/src/modules/reusable/components/Metadata/index.js
@@ -253,7 +253,10 @@ function SearchLink({ children, search }) {
 }
 
 function createSearchURL({ type, scope, value, institution, datastoreUid }) {
-  const query = type === "fielded" ? `${scope}:${value}` : {};
+  const query =
+    type === "fielded" ? `${scope}:${value}` :
+    type === "specified" ? value :
+    {};
   const filter = type === "filtered" ? { [scope]: value } : {};
   let library = {};
 


### PR DESCRIPTION
For a "specified" search use the value directly without prepending a field name.

# Pull Request

## Description

LIBSEARCH-84

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual testing with record [990058888520106381](https://search.lib.umich.edu/catalog/record/990058888520106381). 

### This has been tested on the following browser(s)

- [x] Chrome

### This has been tested for Accessibility with the following:

HTML structure has not changed.  url generation for text links has.
