### PR TITLE
[LIBSEARCH-818] In TESTING environment, set "Keyword (contains)" as default Articles search option

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -3,8 +3,8 @@ const spectrum = process.env.REACT_APP_SPECTRUM_BASE_URL
   : window.location.origin;
 
 const loginUrl = process.env.REACT_APP_LOGIN_BASE_URL
-  ? process.env.REACT_APP_LOGIN_BASE_URL + "/login"
-  : window.location.origin + "/login";
+  ? process.env.REACT_APP_LOGIN_BASE_URL + '/login'
+  : window.location.origin + '/login';
 
 const config = {
   spectrum,
@@ -12,341 +12,341 @@ const config = {
   datastores: {
     list: [
       {
-        uid: "mirlyn",
-        name: "Catalog",
-        slug: "catalog",
+        uid: 'mirlyn',
+        name: 'Catalog',
+        slug: 'catalog'
       },
       {
-        uid: "primo",
-        name: "Articles",
-        slug: "articles",
+        uid: 'primo',
+        name: 'Articles',
+        slug: 'articles'
       },
       {
-        uid: "databases",
-        name: "Databases",
+        uid: 'databases',
+        name: 'Databases'
       },
       {
-        uid: "onlinejournals",
-        name: "Online Journals",
-        slug: "onlinejournals",
+        uid: 'onlinejournals',
+        name: 'Online Journals',
+        slug: 'onlinejournals'
       },
       {
-        uid: "website",
-        name: "Guides and More",
-        slug: "guidesandmore",
+        uid: 'website',
+        name: 'Guides and More',
+        slug: 'guidesandmore'
       },
       {
-        uid: "everything",
-        name: "Everything",
+        uid: 'everything',
+        name: 'Everything',
         datastores: [
-          "mirlyn",
-          "primo",
-          "databases",
-          "onlinejournals",
-          "website",
-        ],
-      },
+          'mirlyn',
+          'primo',
+          'databases',
+          'onlinejournals',
+          'website'
+        ]
+      }
     ],
     ordering: [
-      "everything",
-      "mirlyn",
-      "primo",
-      "onlinejournals",
-      "databases",
-      "website",
+      'everything',
+      'mirlyn',
+      'primo',
+      'onlinejournals',
+      'databases',
+      'website'
     ],
-    default: "everything",
+    default: 'everything'
   },
   sorts: {
     mirlyn: {
-      default: "relevance",
+      default: 'relevance',
       sorts: [
-        "relevance",
-        "date_asc",
-        "date_desc",
-        "author_asc",
-        "author_desc",
-        "date_added",
-        "title_asc",
-        "title_desc",
-      ],
+        'relevance',
+        'date_asc',
+        'date_desc',
+        'author_asc',
+        'author_desc',
+        'date_added',
+        'title_asc',
+        'title_desc'
+      ]
     },
     primo: {
-      default: "relevance",
+      default: 'relevance',
       sorts: [
-        "relevance",
-        "date_asc",
-        "date_desc",
-        "author",
-        "title",
-      ],
+        'relevance',
+        'date_asc',
+        'date_desc',
+        'author',
+        'title'
+      ]
     },
     databases: {
-      default: "relevance",
-      sorts: ["relevance", "title_asc", "title_desc"],
+      default: 'relevance',
+      sorts: ['relevance', 'title_asc', 'title_desc']
     },
     onlinejournals: {
-      default: "relevance",
+      default: 'relevance',
       sorts: [
-        "relevance",
-        "date_asc",
-        "date_desc",
-        "date_added",
-        "title_asc",
-        "title_desc",
-      ],
+        'relevance',
+        'date_asc',
+        'date_desc',
+        'date_added',
+        'title_asc',
+        'title_desc'
+      ]
     },
     website: {
-      default: "relevance",
-      sorts: ["relevance", "title_asc", "title_desc", "date_asc", "date_desc"],
-    },
+      default: 'relevance',
+      sorts: ['relevance', 'title_asc', 'title_desc', 'date_asc', 'date_desc']
+    }
   },
-  advancedBooleanTypes: ["AND", "OR", "NOT"],
+  advancedBooleanTypes: ['AND', 'OR', 'NOT'],
   advanced: {
     everything: {
       forcedFields: [
         {
-          uid: "keyword",
-          name: "Keyword",
-          force: true,
+          uid: 'keyword',
+          name: 'Keyword',
+          force: true
         },
         {
-          uid: "title",
-          name: "Title",
-          force: true,
+          uid: 'title',
+          name: 'Title',
+          force: true
         },
         {
-          uid: "author",
-          name: "Author",
-          force: true,
-        },
+          uid: 'author',
+          name: 'Author',
+          force: true
+        }
       ],
-      fields: ["keyword", "title", "author"],
-      defaultFields: ["keyword", "title", "author"],
+      fields: ['keyword', 'title', 'author'],
+      defaultFields: ['keyword', 'title', 'author']
     },
     mirlyn: {
       fields: [
-        "keyword",
-        "title",
-        "title_starts_with",
-        "author",
-        "journal_title",
-        "subject",
-        "academic_discipline",
-        "call_number_starts_with",
-        "publisher",
-        "series",
-        "publication_date",
-        "isn",
+        'keyword',
+        'title',
+        'title_starts_with',
+        'author',
+        'journal_title',
+        'subject',
+        'academic_discipline',
+        'call_number_starts_with',
+        'publisher',
+        'series',
+        'publication_date',
+        'isn'
       ],
-      defaultFields: ["keyword", "title", "author"],
+      defaultFields: ['keyword', 'title', 'author'],
       filters: [
         {
-          uid: "available_online",
-          type: "checkbox",
-          groupBy: "Access Options",
+          uid: 'available_online',
+          type: 'checkbox',
+          groupBy: 'Access Options',
           conditions: {
             checked: true,
-            unchecked: undefined,
-          },
+            unchecked: undefined
+          }
         },
         {
-          uid: "search_only",
-          name: "Remove Search Only HathiTrust Materials",
-          groupBy: "Access Options",
-          type: "checkbox",
+          uid: 'search_only',
+          name: 'Remove Search Only HathiTrust Materials',
+          groupBy: 'Access Options',
+          type: 'checkbox',
           conditions: {
             checked: undefined,
             unchecked: false,
-            default: "checked",
-          },
+            default: 'checked'
+          }
         },
         {
-          uid: "narrow_search",
-          type: "scope_down",
-          name: "Narrow Search To",
+          uid: 'narrow_search',
+          type: 'scope_down',
+          name: 'Narrow Search To',
           defaults: [
             {
-              uid: "institution",
-              value: "All libraries",
+              uid: 'institution',
+              value: 'All libraries'
             },
             {
-              uid: "location",
-              value: "All locations",
+              uid: 'location',
+              value: 'All locations'
             },
             {
-              uid: "collection",
-              value: "All collections",
-            },
-          ],
+              uid: 'collection',
+              value: 'All collections'
+            }
+          ]
         },
         {
-          uid: "date_of_publication",
-          type: "date_range_input",
+          uid: 'date_of_publication',
+          type: 'date_range_input'
         },
         {
-          uid: "academic_discipline",
-          type: "multiple_select",
+          uid: 'academic_discipline',
+          type: 'multiple_select'
         },
         {
-          uid: "language",
-          type: "multiple_select",
+          uid: 'language',
+          type: 'multiple_select'
         },
         {
-          uid: "format",
-          type: "multiple_select",
+          uid: 'format',
+          type: 'multiple_select'
         },
         {
-          uid: "place_of_publication_filter",
-          type: "multiple_select",
-        },
-      ],
+          uid: 'place_of_publication_filter',
+          type: 'multiple_select'
+        }
+      ]
     },
     primo: {
       fields: [
-        "keyword",
-        "contains",
-        "title",
-        "author",
-        "publication_title",
-        "subject",
-        "publication_date",
-        "issn",
-        "isbn"
+        'keyword',
+        'exact',
+        'title',
+        'author',
+        'publication_title',
+        'subject',
+        'publication_date',
+        'issn',
+        'isbn'
       ],
-      defaultFields: ["keyword", "title", "author"],
+      defaultFields: ['keyword', 'title', 'author'],
       filters: [
         {
-          uid: "available_online",
-          name: "Limit to articles available online",
-          type: "checkbox",
-          groupBy: "Access Options",
+          uid: 'available_online',
+          name: 'Limit to articles available online',
+          type: 'checkbox',
+          groupBy: 'Access Options',
           conditions: {
             checked: true,
-            unchecked: undefined,
-          },
+            unchecked: undefined
+          }
         },
         {
-          uid: "is_scholarly",
-          name: "Limit to articles from scholarly journals",
-          groupBy: "Access Options",
-          type: "checkbox",
+          uid: 'is_scholarly',
+          name: 'Limit to articles from scholarly journals',
+          groupBy: 'Access Options',
+          type: 'checkbox',
           conditions: {
             checked: true,
-            unchecked: undefined,
-          },
+            unchecked: undefined
+          }
         },
         {
-          uid: "holdings_only",
+          uid: 'holdings_only',
           name: "Add results beyond the library's holdings",
-          groupBy: "Access Options",
-          type: "checkbox",
+          groupBy: 'Access Options',
+          type: 'checkbox',
           conditions: {
             checked: false,
-            unchecked: undefined,
-          },
+            unchecked: undefined
+          }
         },
         {
-          uid: "exclude_newspapers",
-          name: "Exclude newspaper holdings",
-          groupBy: "Access Options",
-          type: "checkbox",
+          uid: 'exclude_newspapers',
+          name: 'Exclude newspaper holdings',
+          groupBy: 'Access Options',
+          type: 'checkbox',
           conditions: {
             checked: true,
-            unchecked: undefined,
-          },
+            unchecked: undefined
+          }
         },
         {
-          uid: "publication_date",
-          type: "date_range_input",
+          uid: 'publication_date',
+          type: 'date_range_input'
         },
         {
-          uid: "language",
-          type: "multiple_select",
+          uid: 'language',
+          type: 'multiple_select'
         },
         {
-          uid: "format",
-          type: "multiple_select",
+          uid: 'format',
+          type: 'multiple_select'
         }
       ]
     },
     databases: {
       fields: [
-        "keyword",
-        "title",
-        "title_starts_with",
-        "academic_discipline",
-        "publisher",
+        'keyword',
+        'title',
+        'title_starts_with',
+        'academic_discipline',
+        'publisher'
       ],
-      defaultFields: ["keyword", "title_starts_with"],
+      defaultFields: ['keyword', 'title_starts_with'],
       filters: [
         {
-          uid: "type",
-          type: "multiple_select",
+          uid: 'type',
+          type: 'multiple_select'
         },
         {
-          uid: "academic_discipline",
-          type: "multiple_select",
+          uid: 'academic_discipline',
+          type: 'multiple_select'
         },
         {
-          uid: "access_type",
-          type: "multiple_select",
-        },
-      ],
+          uid: 'access_type',
+          type: 'multiple_select'
+        }
+      ]
     },
     onlinejournals: {
-       fields: [
-        "keyword",
-        "title",
-        "title_starts_with",
-        "subject",
-        "academic_discipline",
-        "call_number_starts_with",
-        "isn",
+      fields: [
+        'keyword',
+        'title',
+        'title_starts_with',
+        'subject',
+        'academic_discipline',
+        'call_number_starts_with',
+        'isn'
       ],
       filters: [
         {
-          uid: "subject",
-          type: "multiple_select",
+          uid: 'subject',
+          type: 'multiple_select'
         },
         {
-          uid: "language",
-          type: "multiple_select",
+          uid: 'language',
+          type: 'multiple_select'
         },
         {
-          uid: "place_of_publication_filter",
-          type: "multiple_select",
+          uid: 'place_of_publication_filter',
+          type: 'multiple_select'
         },
         {
-          uid: "academic_discipline",
-          type: "multiple_select",
-        },
+          uid: 'academic_discipline',
+          type: 'multiple_select'
+        }
       ],
-      defaultFields: ["keyword", "title", "subject"],
+      defaultFields: ['keyword', 'title', 'subject']
     },
     website: {
-      fields: ["keyword", "title"],
-      defaultFields: ["keyword"],
-    },
+      fields: ['keyword', 'title'],
+      defaultFields: ['keyword']
+    }
   },
   holdingRewrites: [
     {
       match: {
-        uid: "status",
-        value: "Search only (no full text)",
+        uid: 'status',
+        value: 'Search only (no full text)'
       },
       replace: [
         {
-          uid: "linkText",
-          value: "Search keyword frequency",
+          uid: 'linkText',
+          value: 'Search keyword frequency'
         },
         {
-          uid: "linkStyle",
-          value: "link",
-        },
-      ],
-    },
-  ],
+          uid: 'linkStyle',
+          value: 'link'
+        }
+      ]
+    }
+  ]
 };
 
 export default config;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -205,6 +205,7 @@ const config = {
     primo: {
       fields: [
         'keyword',
+        'contains',
         'exact',
         'title',
         'author',

--- a/src/modules/records/components/KeywordSwitch/index.js
+++ b/src/modules/records/components/KeywordSwitch/index.js
@@ -1,18 +1,17 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Icon } from '../../../reusable';
-import {
-  COLORS
-} from '../../../reusable/umich-lib-core-temp'
+import { COLORS } from '../../../reusable/umich-lib-core-temp';
 
 class KeywordSwitch extends React.Component {
-  render() {
+  render () {
     const { datastore, query } = this.props;
     const containsKeyword = query.startsWith('contains');
 
     if (datastore.uid !== 'primo' || (query.search(/:\(/) !== -1 && !containsKeyword)) return null;
 
-    const querySearch = containsKeyword? query.slice(10, -1) : `contains:(${query})`;
+    const querySearch = containsKeyword ? query.slice(10, -1) : `contains:(${query})`;
     const linkURL = `${datastore.slug}?query=${querySearch}`;
     const briefView = window.location.pathname.split('/').pop() === 'everything';
     const descriptionText = !briefView && containsKeyword ? 'Seeing less precise results than you expected?' : 'Not seeing the results you expected?';
@@ -21,7 +20,7 @@ class KeywordSwitch extends React.Component {
         return briefView ? 'Try an exact phrase Articles search.' : 'Try your search as an exact phrase search.';
       }
       return briefView ? 'Try an Articles search that contains these terms.' : 'Broaden your search to include items that contain these terms and related words.';
-    }
+    };
 
     return (
       <div
@@ -31,7 +30,7 @@ class KeywordSwitch extends React.Component {
         }}
       >
         <div
-          className={`keyword-switch ${!briefView  && 'record-container'}`}
+          className={`keyword-switch ${!briefView && 'record-container'}`}
           css={{
             position: 'relative'
           }}
@@ -72,5 +71,10 @@ class KeywordSwitch extends React.Component {
     );
   }
 }
+
+KeywordSwitch.propTypes = {
+  datastore: PropTypes.object,
+  query: PropTypes.string
+};
 
 export default KeywordSwitch;

--- a/src/modules/records/components/KeywordSwitch/index.js
+++ b/src/modules/records/components/KeywordSwitch/index.js
@@ -13,7 +13,8 @@ class KeywordSwitch extends React.Component {
 
     if (datastore.uid !== 'primo' || (!isExactSearch && !isContainsSearch)) return null;
 
-    const querySearch = isExactSearch ? query.slice(exactQuery.length, -1) : `${exactQuery}${query})`;
+    const strippedQuery = query.includes(':(') ? query.slice((query.indexOf('(') + 1), -1) : query;
+    const querySearch = isExactSearch ? strippedQuery : `${exactQuery}${strippedQuery})`;
     const linkURL = `${datastore.slug}?query=${querySearch}`;
     const briefView = window.location.pathname.split('/').pop() === 'everything';
     const descriptionText = !briefView && isContainsSearch ? 'Seeing less precise results than you expected?' : 'Not seeing the results you expected?';

--- a/src/modules/records/components/KeywordSwitch/index.js
+++ b/src/modules/records/components/KeywordSwitch/index.js
@@ -7,16 +7,18 @@ import { COLORS } from '../../../reusable/umich-lib-core-temp';
 class KeywordSwitch extends React.Component {
   render () {
     const { datastore, query } = this.props;
-    const containsKeyword = query.startsWith('contains');
+    const exactQuery = 'exact:(';
+    const isExactSearch = query.startsWith(exactQuery);
+    const isContainsSearch = query.startsWith('contains:(') || query.startsWith('keyword:(') || !query.includes(':(');
 
-    if (datastore.uid !== 'primo' || (query.search(/:\(/) !== -1 && !containsKeyword)) return null;
+    if (datastore.uid !== 'primo' || (!isExactSearch && !isContainsSearch)) return null;
 
-    const querySearch = containsKeyword ? query.slice(10, -1) : `contains:(${query})`;
+    const querySearch = isExactSearch ? query.slice(exactQuery.length, -1) : `${exactQuery}${query})`;
     const linkURL = `${datastore.slug}?query=${querySearch}`;
     const briefView = window.location.pathname.split('/').pop() === 'everything';
-    const descriptionText = !briefView && containsKeyword ? 'Seeing less precise results than you expected?' : 'Not seeing the results you expected?';
+    const descriptionText = !briefView && isContainsSearch ? 'Seeing less precise results than you expected?' : 'Not seeing the results you expected?';
     const linkText = () => {
-      if (containsKeyword) {
+      if (isContainsSearch) {
         return briefView ? 'Try an exact phrase Articles search.' : 'Try your search as an exact phrase search.';
       }
       return briefView ? 'Try an Articles search that contains these terms.' : 'Broaden your search to include items that contain these terms and related words.';

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -1,21 +1,32 @@
 /** @jsxImportSource @emotion/react */
-import { Global } from "@emotion/react";
-import React from 'react'
-import { MEDIA_QUERIES, SEARCH_COLORS } from "../../../reusable/umich-lib-core-temp";
-import { Icon, Button } from "../../../reusable";
-import { useSelector } from "react-redux";
-import qs from "qs";
-import { withRouter } from "react-router";
-import { Link } from "react-router-dom";
-import SearchByOptions from "../SearchByOptions";
-import SearchTip from "../SearchTip";
+import { Global } from '@emotion/react';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MEDIA_QUERIES, SEARCH_COLORS } from '../../../reusable/umich-lib-core-temp';
+import { Icon, Button } from '../../../reusable';
+import { useSelector } from 'react-redux';
+import qs from 'qs';
+import { withRouter } from 'react-router';
+import { Link } from 'react-router-dom';
+import SearchByOptions from '../SearchByOptions';
+import SearchTip from '../SearchTip';
 
-function SearchBox({ history, match, location }) {
-  const { query } = useSelector((state) => state.search);
-  const { fields } = useSelector((state) => state.advanced[state.datastores.active]);
-  const isAdvanced = useSelector((state) => state.advanced[state.datastores.active] ? true : false)
+function SearchBox ({ history, match, location }) {
+  const { query } = useSelector((state) => {
+    return state.search;
+  });
+  const { fields } = useSelector((state) => {
+    return state.advanced[state.datastores.active];
+  });
+  const isAdvanced = useSelector((state) => {
+    return !!state.advanced[state.datastores.active];
+  });
   const activeDatastore = useSelector(
-    (state) => state.datastores.datastores.find(ds => ds.uid === state.datastores.active)
+    (state) => {
+      return state.datastores.datastores.find((ds) => {
+        return ds.uid === state.datastores.active;
+      });
+    }
   );
   const [inputQuery, setInputQuery] = React.useState(query);
   const defaultField = fields[0].uid;
@@ -28,11 +39,15 @@ function SearchBox({ history, match, location }) {
     // Set default value of input
     let getInput = query;
     // Check if the query is a single fielded search
-    if(query.includes(':(') && ![' AND ', ' OR ', ' NOT '].some((boolean) => query.includes(boolean))) {
+    if (query.includes(':(') && ![' AND ', ' OR ', ' NOT '].some((boolean) => {
+      return query.includes(boolean);
+    })) {
       // Get current search field uid from query
       const currentQuery = query.slice(0, query.indexOf(':'));
       // Check if current query exists in active datastore's field options
-      if (fields.map(field => field.uid).includes(currentQuery)) {
+      if (fields.map((field) => {
+        return field.uid;
+      }).includes(currentQuery)) {
         // Update field to current query
         getField = currentQuery;
         // Remove field wrap from input value
@@ -44,8 +59,8 @@ function SearchBox({ history, match, location }) {
     // Set input value
     setInputQuery(getInput);
   }, [activeDatastore, query]);
-  
-  function setOption(e) {
+
+  function setOption (e) {
     window.dataLayer.push({
       event: 'selectionMade',
       selectedElement: e.target.options[e.target.selectedIndex]
@@ -53,7 +68,7 @@ function SearchBox({ history, match, location }) {
     return setField(e.target.value);
   }
 
-  function handleSubmitSearch(e) {
+  function handleSubmitSearch (e) {
     e.preventDefault();
 
     // Get the dropdown's current value because `field` does not change
@@ -83,10 +98,10 @@ function SearchBox({ history, match, location }) {
       // Add new query
       query: newQuery
     }, {
-      arrayFormat: "repeat",
+      arrayFormat: 'repeat',
       encodeValuesOnly: true,
       allowDots: true,
-      format: "RFC1738"
+      format: 'RFC1738'
     });
 
     // Redirect users if browse option has been submitted
@@ -98,19 +113,25 @@ function SearchBox({ history, match, location }) {
   }
 
   return (
-    <form css={{
-      background: SEARCH_COLORS.blue['300'],
-      paddingBottom: `0.75rem`,
-      borderBottom: `solid 2px ${SEARCH_COLORS.blue['400']}`
-    }} onSubmit={handleSubmitSearch}>
+    <form
+      css={{
+        background: SEARCH_COLORS.blue['300'],
+        paddingBottom: '0.75rem',
+        borderBottom: `solid 2px ${SEARCH_COLORS.blue['400']}`
+      }}
+      onSubmit={() => {
+        return handleSubmitSearch;
+      }}
+    >
       <Global styles={{
         '*:focus': {
           outline: 0,
-          boxShadow: `rgb(255, 203, 5) 0px 0px 0px 2px, rgb(33, 43, 54) 0px 0px 0px 3px !important`,
+          boxShadow: 'rgb(255, 203, 5) 0px 0px 0px 2px, rgb(33, 43, 54) 0px 0px 0px 3px !important',
           zIndex: '10',
           borderRadius: '2px !important'
         }
-      }}/>
+      }}
+      />
       <div
         css={{
           maxWidth: '1280px',
@@ -133,28 +154,31 @@ function SearchBox({ history, match, location }) {
             gridTemplateAreas:
             `'dropdown input button'
              'advanced advanced advanced'`,
-            gridTemplateColumns: '290px 1fr auto',
+            gridTemplateColumns: '290px 1fr auto'
           },
           '@media only screen and (min-width: 820px)': {
-            gridTemplateAreas: `'dropdown input button advanced'`,
-            gridTemplateColumns: '340px 1fr auto auto',
+            gridTemplateAreas: '\'dropdown input button advanced\'',
+            gridTemplateColumns: '340px 1fr auto auto'
           }
-        }}>
-          <div 
-            className="search-box-dropdown" 
+        }}
+        >
+          <div
+            className='search-box-dropdown'
             css={{
               gridArea: 'dropdown',
               marginTop: '0.75rem',
               position: 'relative',
-              width: '100%',
+              width: '100%'
             }}
           >
             <select
-              aria-label="Select an option"
-              className="dropdown"
+              aria-label='Select an option'
+              className='dropdown'
               value={field}
-              onChange={e => setOption(e)}
-              autoComplete="off"
+              onChange={(e) => {
+                return setOption(e);
+              }}
+              autoComplete='off'
               css={{
                 all: 'unset',
                 background: SEARCH_COLORS.grey['100'],
@@ -176,23 +200,25 @@ function SearchBox({ history, match, location }) {
               <SearchByOptions activeDatastore={activeDatastore} fields={fields} />
             </select>
             <Icon
-              icon="expand_more"
+              icon='expand_more'
               size={24}
               css={{
                 position: 'absolute',
                 right: '0.5rem',
                 top: '0.6rem',
                 pointerEvents: 'none'
-              }} 
+              }}
             />
           </div>
           <input
-            type="text"
-            aria-label={field.startsWith('browse_by_') ? `Browse for` : `Search for`}
+            type='text'
+            aria-label={field.startsWith('browse_by_') ? 'Browse for' : 'Search for'}
             value={inputQuery}
-            onChange={e => setInputQuery(e.target.value)}
-            autoComplete="on"
-            name="query"
+            onChange={(e) => {
+              return setInputQuery(e.target.value);
+            }}
+            autoComplete='on'
+            name='query'
             css={{
               all: 'unset',
               background: 'white',
@@ -222,7 +248,7 @@ function SearchBox({ history, match, location }) {
             }}
             type='submit'
           >
-            <Icon icon="search" size={24} />
+            <Icon icon='search' size={24} />
             <span css={{
               border: '0px',
               clip: 'rect(0px, 0px, 0px, 0px)',
@@ -234,12 +260,15 @@ function SearchBox({ history, match, location }) {
               width: '1px',
               whiteSpace: 'nowrap',
               overflowWrap: 'normal'
-            }}>Search</span>
+            }}
+            >
+              Search
+            </span>
           </Button>
           {isAdvanced && (
             <Link
               to={`/${match.params.datastoreSlug}/advanced${location.search}`}
-              className="search-box-advanced-link"
+              className='search-box-advanced-link'
               css={{
                 alignSelf: 'center',
                 gridArea: 'advanced',
@@ -248,16 +277,22 @@ function SearchBox({ history, match, location }) {
                 textAlign: 'center'
               }}
             >
-              <span className="offpage">{activeDatastore.name}</span>
+              <span className='offpage'>{activeDatastore.name}</span>
               <span>Advanced</span>
-              <span className="offpage">Search</span>
+              <span className='offpage'>Search</span>
             </Link>
           )}
         </div>
         <SearchTip activeDatastore={activeDatastore} field={field} />
       </div>
     </form>
-  )
+  );
 }
+
+SearchBox.propTypes = {
+  history: PropTypes.object,
+  match: PropTypes.object,
+  location: PropTypes.object
+};
 
 export default withRouter(SearchBox);

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -29,18 +29,18 @@ function SearchBox ({ history, match, location }) {
     }
   );
   const [inputQuery, setInputQuery] = React.useState(query);
-  const defaultField = fields[0].uid;
+  const defaultField = fields[activeDatastore.uid === 'primo' && !query ? 1 : 0].uid;
   const [field, setField] = React.useState(defaultField);
 
   // Set field and input when `activeDatastore` or `query` changes
   React.useEffect(() => {
-    // Set default value of field
-    let getField = defaultField;
+    // Set default value of field based on the query
+    let getField = query && !query.includes(':(') ? fields[0].uid : defaultField;
     // Set default value of input
     let getInput = query;
     // Check if the query is a single fielded search
-    if (query.includes(':(') && ![' AND ', ' OR ', ' NOT '].some((boolean) => {
-      return query.includes(boolean);
+    if (query && query.includes(':(') && ![' AND ', ' OR ', ' NOT '].some((operator) => {
+      return query.includes(operator);
     })) {
       // Get current search field uid from query
       const currentQuery = query.slice(0, query.indexOf(':'));
@@ -84,7 +84,7 @@ function SearchBox ({ history, match, location }) {
     const browseURL = browseOption ? `/browse/${dropdownOption.slice(10)}` : '';
 
     // Set new query
-    const newQuery = (browseOption || dropdownOption === defaultField) ? inputQuery : `${dropdownOption}:(${inputQuery})`;
+    const newQuery = (browseOption || dropdownOption === 'keyword') ? inputQuery : `${dropdownOption}:(${inputQuery})`;
 
     // Check if new search
     if (query === newQuery) return;
@@ -119,8 +119,8 @@ function SearchBox ({ history, match, location }) {
         paddingBottom: '0.75rem',
         borderBottom: `solid 2px ${SEARCH_COLORS.blue['400']}`
       }}
-      onSubmit={() => {
-        return handleSubmitSearch;
+      onSubmit={(e) => {
+        return handleSubmitSearch(e);
       }}
     >
       <Global styles={{

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -29,13 +29,13 @@ function SearchBox ({ history, match, location }) {
     }
   );
   const [inputQuery, setInputQuery] = React.useState(query);
-  const defaultField = fields[activeDatastore.uid === 'primo' && !query ? 1 : 0].uid;
+  const defaultField = fields[0].uid;
   const [field, setField] = React.useState(defaultField);
 
   // Set field and input when `activeDatastore` or `query` changes
   React.useEffect(() => {
-    // Set default value of field based on the query
-    let getField = query && !query.includes(':(') ? fields[0].uid : defaultField;
+    // Set default value of field
+    let getField = defaultField;
     // Set default value of input
     let getInput = query;
     // Check if the query is a single fielded search
@@ -84,7 +84,7 @@ function SearchBox ({ history, match, location }) {
     const browseURL = browseOption ? `/browse/${dropdownOption.slice(10)}` : '';
 
     // Set new query
-    const newQuery = (browseOption || dropdownOption === 'keyword') ? inputQuery : `${dropdownOption}:(${inputQuery})`;
+    const newQuery = (browseOption || dropdownOption === defaultField) ? inputQuery : `${dropdownOption}:(${inputQuery})`;
 
     // Check if new search
     if (query === newQuery) return;

--- a/src/modules/search/utilities/index.js
+++ b/src/modules/search/utilities/index.js
@@ -1,108 +1,108 @@
 const searchOptions = () => {
   return [
     {
-      "name": "Keyword",
-      "uid": "keyword",
-      "tip": "Enter one or more keywords. Use quotes to search for a phrase (e.g. solar power; polar bears; “systems of oppression”). See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>.",
-      "datastore": "mirlyn"
+      name: 'Keyword',
+      uid: 'keyword',
+      tip: 'Enter one or more keywords. Use quotes to search for a phrase (e.g. solar power; polar bears; “systems of oppression”). See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching</a>.',
+      datastore: 'mirlyn'
     },
     {
-      "name": "Keyword (is exact)",
-      "uid": "keyword",
-      "tip": "Enter an exact phrase to search (e.g., solar power). Use AND to separate concepts or phrases (e.g., Black Women Scientists AND Chanda Prescod). See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>.",
-      "datastore": "primo"
+      name: 'Keyword (is exact)',
+      uid: 'keyword',
+      tip: 'Enter an exact phrase to search (e.g., solar power). Use AND to separate concepts or phrases (e.g., Black Women Scientists AND Chanda Prescod). See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching</a>.',
+      datastore: 'primo'
     },
     {
-      "name": "Keyword (contains)",
-      "uid": "contains",
-      "tip": "Enter one or more keywords to search broadly. (e.g., Black Women Scientists) Use quotes to search for a specific phrase. (e.g., “systems of oppression”) See tips about <a href=\"https://guides.lib.umich.edu/c.php?g=914690&p=6590011\">Basic Keyword Searching</a>.",
-      "datastore": "primo"
+      name: 'Keyword (contains)',
+      uid: 'contains',
+      tip: 'Enter one or more keywords to search broadly. (e.g., Black Women Scientists) Use quotes to search for a specific phrase. (e.g., “systems of oppression”) See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching</a>.',
+      datastore: 'primo'
     },
     {
-      "name": "Title",
-      "uid": "title",
-      "tip": "Enter the first words in an article title. Use quotes to search for a phrase. (e.g., Culture as disability).",
-      "datastore": ["mirlyn", "primo"]
+      name: 'Title',
+      uid: 'title',
+      tip: 'Enter the first words in an article title. Use quotes to search for a phrase. (e.g., Culture as disability).',
+      datastore: ['mirlyn', 'primo']
     },
     {
-      "name": "Title starts with",
-      "uid": "title_starts_with",
-      "tip": "Search for titles that begin with a word or phrase (e.g., introduction to chemistry; history of Mexico; Asian art).",
-      "datastore": "mirlyn"
+      name: 'Title starts with',
+      uid: 'title_starts_with',
+      tip: 'Search for titles that begin with a word or phrase (e.g., introduction to chemistry; history of Mexico; Asian art).',
+      datastore: 'mirlyn'
     },
     {
-      "name": "Author",
-      "uid": "author",
-      "tip": "Search for items by author or contributor. (e.g., Kimmerer, Robin Wall) Also search organizations or corporate authors. (e.g., American Medical Association). Search for items by author using original scripts (e.g. 小川 洋子)",
-      "datastore": ["mirlyn", "primo"]
+      name: 'Author',
+      uid: 'author',
+      tip: 'Search for items by author or contributor. (e.g., Kimmerer, Robin Wall) Also search organizations or corporate authors. (e.g., American Medical Association). Search for items by author using original scripts (e.g. 小川 洋子)',
+      datastore: ['mirlyn', 'primo']
     },
     {
-      "name": "Journal/Serial Title",
-      "uid": "journal_title",
-      "tip": "Search the title of a journal or serial publication (e.g. Detroit Free Press; “journal of the american medical association”; African-American newspapers).",
-      "datastore": "mirlyn"
+      name: 'Journal/Serial Title',
+      uid: 'journal_title',
+      tip: 'Search the title of a journal or serial publication (e.g. Detroit Free Press; “journal of the american medical association”; African-American newspapers).',
+      datastore: 'mirlyn'
     },
     {
-      "name": "Subject contains",
-      "uid": "subject",
-      "tip": "Use words or phrases to search subjects. (e.g., plant physiology; Baldwin, James)",
-      "datastore": ["mirlyn", "primo"]
+      name: 'Subject contains',
+      uid: 'subject',
+      tip: 'Use words or phrases to search subjects. (e.g., plant physiology; Baldwin, James)',
+      datastore: ['mirlyn', 'primo']
     },
     {
-      "name": "Call Number starts with",
-      "uid": "call_number_starts_with",
-      "tip": "Search the first few letters and numbers of a call number (e.g. RC662.4 .H38 2016; QH 105). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
-      "datastore": "mirlyn"
+      name: 'Call Number starts with',
+      uid: 'call_number_starts_with',
+      tip: 'Search the first few letters and numbers of a call number (e.g. RC662.4 .H38 2016; QH 105). <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers<span class="visually-hidden"> (link points to external site)</span></a>.',
+      datastore: 'mirlyn'
     },
     {
-      "name": "Series title",
-      "uid": "series",
-      "tip": "Search the series title of a group of thematically-related books. Use ‘title’ search to find unique titles within a series (e.g., Politics of Race and Ethnicity, Brill's Annotated Bibliographies, Oxford Choral Music).",
-      "datastore": "mirlyn"
+      name: 'Series title',
+      uid: 'series',
+      tip: "Search the series title of a group of thematically-related books. Use ‘title’ search to find unique titles within a series (e.g., Politics of Race and Ethnicity, Brill's Annotated Bibliographies, Oxford Choral Music).",
+      datastore: 'mirlyn'
     },
     {
-      "name": "Date",
-      "uid": "publication_date",
-      "tip": "Search by year (YYYY) (e.g. 2021; 1942).",
-      "datastore": "primo"
+      name: 'Date',
+      uid: 'publication_date',
+      tip: 'Search by year (YYYY) (e.g. 2021; 1942).',
+      datastore: 'primo'
     },
     {
-      "name": "ISBN/ISSN/OCLC/etc",
-      "uid": "isn",
-      "tip": "Search by ISSN (8-digit code), ISBN (13- or 10-digit code), or OCLC number (e.g.  0040-781X; 0747581088; 921446069).",
-      "datastore": "mirlyn"
+      name: 'ISBN/ISSN/OCLC/etc',
+      uid: 'isn',
+      tip: 'Search by ISSN (8-digit code), ISBN (13- or 10-digit code), or OCLC number (e.g.  0040-781X; 0747581088; 921446069).',
+      datastore: 'mirlyn'
     },
     {
-      "name": "ISSN",
-      "uid": "issn",
-      "tip": "Search by ISSN (8-digit code) (e.g., 0040-781X).",
-      "datastore": "primo"
+      name: 'ISSN',
+      uid: 'issn',
+      tip: 'Search by ISSN (8-digit code) (e.g., 0040-781X).',
+      datastore: 'primo'
     },
     {
-      "name": "ISBN",
-      "uid": "isbn",
-      "tip": "Search by ISBN (13 or 10-digit code) (e.g., 0747581088).",
-      "datastore": "primo"
+      name: 'ISBN',
+      uid: 'isbn',
+      tip: 'Search by ISBN (13 or 10-digit code) (e.g., 0747581088).',
+      datastore: 'primo'
     },
     {
-      "name": "Browse by call number (LC and Dewey)",
-      "uid": "browse_by_callnumber",
-      "tip": "Browse by Library of Congress (LC) or Dewey call number, sorted alphanumerically (e.g. RC662.4 .H38 2016; QH 105, 880 J375re). <a href=\"https://www.loc.gov/catdir/cpso/lcco/\">Learn about the meaning of call numbers<span class=\"visually-hidden\"> (link points to external site)</span></a>.",
-      "selected": "selected",
-      "datastore": "mirlyn"
+      name: 'Browse by call number (LC and Dewey)',
+      uid: 'browse_by_callnumber',
+      tip: 'Browse by Library of Congress (LC) or Dewey call number, sorted alphanumerically (e.g. RC662.4 .H38 2016; QH 105, 880 J375re). <a href="https://www.loc.gov/catdir/cpso/lcco/">Learn about the meaning of call numbers<span class="visually-hidden"> (link points to external site)</span></a>.',
+      selected: 'selected',
+      datastore: 'mirlyn'
     },
     {
-      "name": "Browse by author",
-      "uid": "browse_by_author",
-      "tip": "Browse an alphabetical list of authors. Authors can be people (put last names first), organizations, or events (e.g. Kingston, Maxine Hong; United Nations Development Programme; Pong, Chun-ho).",
-      "datastore": "mirlyn"
+      name: 'Browse by author',
+      uid: 'browse_by_author',
+      tip: 'Browse an alphabetical list of authors. Authors can be people (put last names first), organizations, or events (e.g. Kingston, Maxine Hong; United Nations Development Programme; Pong, Chun-ho).',
+      datastore: 'mirlyn'
     },
     {
-      "name": "Browse by subject (coming soon)",
-      "uid": "browse_by_subject",
-      "tip": "Browse an A-Z list of subjects (e.g. motion pictures; history--United States; Eliot, George).",
-      "disabled": "disabled",
-      "datastore": "mirlyn"
+      name: 'Browse by subject (coming soon)',
+      uid: 'browse_by_subject',
+      tip: 'Browse an A-Z list of subjects (e.g. motion pictures; history--United States; Eliot, George).',
+      disabled: 'disabled',
+      datastore: 'mirlyn'
     }
   ];
 };

--- a/src/modules/search/utilities/index.js
+++ b/src/modules/search/utilities/index.js
@@ -7,15 +7,15 @@ const searchOptions = () => {
       datastore: 'mirlyn'
     },
     {
-      name: 'Keyword (is exact)',
-      uid: 'keyword',
-      tip: 'Enter an exact phrase to search (e.g., solar power). Use AND to separate concepts or phrases (e.g., Black Women Scientists AND Chanda Prescod). See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching</a>.',
-      datastore: 'primo'
-    },
-    {
       name: 'Keyword (contains)',
       uid: 'contains',
       tip: 'Enter one or more keywords to search broadly. (e.g., Black Women Scientists) Use quotes to search for a specific phrase. (e.g., “systems of oppression”) See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching</a>.',
+      datastore: 'primo'
+    },
+    {
+      name: 'Keyword (is exact)',
+      uid: 'keyword',
+      tip: 'Enter an exact phrase to search (e.g., solar power). Use AND to separate concepts or phrases (e.g., Black Women Scientists AND Chanda Prescod). See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching</a>.',
       datastore: 'primo'
     },
     {

--- a/src/modules/search/utilities/index.js
+++ b/src/modules/search/utilities/index.js
@@ -8,13 +8,13 @@ const searchOptions = () => {
     },
     {
       name: 'Keyword (contains)',
-      uid: 'contains',
+      uid: 'keyword',
       tip: 'Enter one or more keywords to search broadly. (e.g., Black Women Scientists) Use quotes to search for a specific phrase. (e.g., “systems of oppression”) See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching</a>.',
       datastore: 'primo'
     },
     {
       name: 'Keyword (is exact)',
-      uid: 'keyword',
+      uid: 'exact',
       tip: 'Enter an exact phrase to search (e.g., solar power). Use AND to separate concepts or phrases (e.g., Black Women Scientists AND Chanda Prescod). See tips about <a href="https://guides.lib.umich.edu/c.php?g=914690&p=6590011">Basic Keyword Searching</a>.',
       datastore: 'primo'
     },


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [LIBSEARCH-818](https://mlit.atlassian.net/browse/LIBSEARCH-818).

> Exact is proving unsatisfactory to most users, most of the time. 
> ...
> Perhaps on a Netlify server… Set Keyword (Contains) to be the default Articles search behavior. 

### Type of change

- [x] Text/content fix (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### This has been tested on the following browser(s)

- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] Opera

### ESLint
The following changed files have fixed `eslint` errors.