### PR TITLE
[LIBSEARCH-820] Add "Browse in call number list" link to full record view

### DIFF
--- a/src/modules/records/components/RecordMetadata/index.js
+++ b/src/modules/records/components/RecordMetadata/index.js
@@ -1,20 +1,22 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Metadata, ContextProvider } from '../../../reusable';
 
-import { Metadata, ContextProvider } from "../../../reusable";
-
-export default function RecordMetadata({ record, kind }) {
+export default function RecordMetadata ({ record, kind }) {
   const metadata = record.metadata;
 
   if (metadata) {
     return (
       <ContextProvider
-        render={context => (
-          <MetadataTypeContainer
-            data={metadata}
-            type={context.viewType}
-            kind={kind}
-          />
-        )}
+        render={(context) => {
+          return (
+            <MetadataTypeContainer
+              data={metadata}
+              type={context.viewType}
+              kind={kind}
+            />
+          );
+        }}
       />
     );
   }
@@ -22,13 +24,18 @@ export default function RecordMetadata({ record, kind }) {
   return null;
 }
 
-function MetadataTypeContainer({ data, type, kind }) {
+RecordMetadata.propTypes = {
+  record: PropTypes.object,
+  kind: PropTypes.string
+};
+
+function MetadataTypeContainer ({ data, type, kind }) {
   const metadata =
-    type === "Preview"
+    type === 'Preview'
       ? data.preview
-      : type === "Medium"
-      ? data.medium
-      : data.full;
+      : type === 'Medium'
+        ? data.medium
+        : data.full;
 
   if (!data) {
     return null;
@@ -36,3 +43,9 @@ function MetadataTypeContainer({ data, type, kind }) {
 
   return <Metadata data={metadata} kind={kind} />;
 }
+
+MetadataTypeContainer.propTypes = {
+  data: PropTypes.object,
+  type: PropTypes.string,
+  kind: PropTypes.string
+};

--- a/src/modules/reusable/components/Metadata/index.js
+++ b/src/modules/reusable/components/Metadata/index.js
@@ -219,10 +219,10 @@ Description.propTypes = {
   ])
 };
 
-function DescriptionItem ({ href, search, children }) {
-  if (href || search) {
+function DescriptionItem ({ href, search, browse, children }) {
+  if (href || search || browse) {
     return (
-      <DescriptionItemLink href={href} search={search}>
+      <DescriptionItemLink href={href} search={search} browse={browse}>
         {children}
       </DescriptionItemLink>
     );
@@ -234,15 +234,46 @@ function DescriptionItem ({ href, search, children }) {
 DescriptionItem.propTypes = {
   href: PropTypes.string,
   search: PropTypes.object,
+  browse: PropTypes.object,
   children: PropTypes.array
 };
 
-function DescriptionItemLink ({ href, search, children }) {
+function DescriptionItemLink ({ href, search, browse, children }) {
   if (href) {
     return (
       <a css={LINK_STYLES.default} href={href}>
         {children}
       </a>
+    );
+  }
+
+  if (browse) {
+    return (
+      <span>
+        {children}
+        <a
+          css={{
+            color: COLORS.neutral['300'],
+            fontSize: '0.875rem',
+            textDecoration: 'underline',
+            ':hover': {
+              textDecorationThickness: '2px'
+            },
+            ':before': {
+              background: COLORS.neutral['400'],
+              content: '""',
+              display: 'inline-block',
+              height: '1em',
+              margin: '0 0.5rem',
+              verticalAlign: 'middle',
+              width: '1px'
+            }
+          }}
+          href={`/catalog/browse/${browse.type}?query=${browse.value}`}
+        >
+          Browse in {browse.type === 'callnumber' ? 'call number' : browse.type} list
+        </a>
+      </span>
     );
   }
 
@@ -252,6 +283,7 @@ function DescriptionItemLink ({ href, search, children }) {
 DescriptionItemLink.propTypes = {
   href: PropTypes.string,
   search: PropTypes.object,
+  browse: PropTypes.object,
   children: PropTypes.array
 };
 

--- a/src/modules/reusable/components/Metadata/index.js
+++ b/src/modules/reusable/components/Metadata/index.js
@@ -1,67 +1,68 @@
 /** @jsxImportSource @emotion/react */
 // eslint-disable-next-line
 import React from "react";
-import { Link } from "react-router-dom";
-import { useSelector } from "react-redux";
+import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 import {
   Icon,
   Expandable,
   ExpandableChildren,
   ExpandableButton
-} from "../../../reusable";
+} from '../../../reusable';
 import {
   SPACING,
   MEDIA_QUERIES,
   COLORS,
-  LINK_STYLES,
-} from "../../umich-lib-core-temp";
-import { stringifySearchQueryForURL } from "../../../pride";
+  LINK_STYLES
+} from '../../umich-lib-core-temp';
+import { stringifySearchQueryForURL } from '../../../pride';
 
 const visuallyHiddenCSS = {
   border: 0,
-  clip: "rect(0 0 0 0)",
-  height: "1px",
-  margin: "-1px",
-  overflow: "hidden",
+  clip: 'rect(0 0 0 0)',
+  height: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
   padding: 0,
-  position: "absolute",
-  width: "1px",
+  position: 'absolute',
+  width: '1px'
 };
 
-export default function Metadata({ data, kind }) {
-  const isCondensed = kind === "condensed";
+export default function Metadata ({ data, kind }) {
+  const isCondensed = kind === 'condensed';
   const metadataCSS = !isCondensed
     ? {
         [MEDIA_QUERIES.LARGESCREEN]: {
-          display: "grid",
-          gridTemplateColumns: "9rem 1fr",
-          gridColumnGap: SPACING["S"],
-          "dt:not(:first-of-type) + dd": {
-            paddingTop: SPACING["XS"],
-          },
-        },
+          display: 'grid',
+          gridTemplateColumns: '9rem 1fr',
+          gridColumnGap: SPACING.S,
+          'dt:not(:first-of-type) + dd': {
+            paddingTop: SPACING.XS
+          }
+        }
       }
     : {
         dt: {
-          ...visuallyHiddenCSS,
+          ...visuallyHiddenCSS
         },
-        "dt:not(:first-of-type) + dd": {
-          paddingTop: SPACING["XS"],
-        },
+        'dt:not(:first-of-type) + dd': {
+          paddingTop: SPACING.XS
+        }
       };
 
   // Only show expandable if more than 5.
-  function expandable(desc) {
+  function expandable (desc) {
     if (desc.length <= 5) {
       return {
         show: desc.length,
-        expandable: false,
+        expandable: false
       };
     }
 
     return {
       show: 4,
-      expandable: true,
+      expandable: true
     };
   }
 
@@ -69,88 +70,99 @@ export default function Metadata({ data, kind }) {
     <dl
       css={{
         ...metadataCSS,
-        "dt:not(:first-of-type)": {
-          paddingTop: SPACING["XS"],
-        },
+        'dt:not(:first-of-type)': {
+          paddingTop: SPACING.XS
+        }
       }}
     >
-      {data.map((d, i) => (
-        <Expandable key={"expandable-metadata-dt-dd-" + i}>
-          <dt
-            css={{
-              gridColumnStart: "1",
-            }}
-          >
-            {d.term}
-          </dt>
-          <ExpandableChildren show={expandable(d.description).show}>
-            {d.description.map((d, i) => (
-              <dd
-                css={{
-                  gridColumnStart: "2",
-                  display: "flex",
-                  alignItems: "top",
-                }}
-                key={"metadata-dd-" + i}
-              >
-                <Description data={d} />
-              </dd>
-            ))}
-          </ExpandableChildren>
-
-          {expandable(d.description).expandable && (
-            <dd
+      {data.map((d, i) => {
+        return (
+          <Expandable key={'expandable-metadata-dt-dd-' + i}>
+            <dt
               css={{
-                gridColumnStart: "2",
-                display: "flex",
-                alignItems: "top",
+                gridColumnStart: '1'
               }}
             >
-              <ExpandableButton
-                name={d.termPlural ? d.termPlural : d.term}
-                count={d.description.length}
-                kind="secondary"
-                small
+              {d.term}
+            </dt>
+            <ExpandableChildren show={expandable(d.description).show}>
+              {d.description.map((d, i) => {
+                return (
+                  <dd
+                    css={{
+                      gridColumnStart: '2',
+                      display: 'flex',
+                      alignItems: 'top'
+                    }}
+                    key={'metadata-dd-' + i}
+                  >
+                    <Description data={d} />
+                  </dd>
+                );
+              })}
+            </ExpandableChildren>
+
+            {expandable(d.description).expandable && (
+              <dd
                 css={{
-                  marginTop: SPACING["XS"],
+                  gridColumnStart: '2',
+                  display: 'flex',
+                  alignItems: 'top'
                 }}
-              />
-            </dd>
-          )}
-        </Expandable>
-      ))}
+              >
+                <ExpandableButton
+                  name={d.termPlural ? d.termPlural : d.term}
+                  count={d.description.length}
+                  kind='secondary'
+                  small
+                  css={{
+                    marginTop: SPACING.XS
+                  }}
+                />
+              </dd>
+            )}
+          </Expandable>
+        );
+      })}
     </dl>
   );
 }
 
-function Description({ data }) {
+Metadata.propTypes = {
+  data: PropTypes.array,
+  kind: PropTypes.string
+};
+
+function Description ({ data }) {
   if (Array.isArray(data)) {
     return (
       <ol
         css={{
-          margin: "0",
-          padding: "0",
+          margin: '0',
+          padding: '0'
         }}
       >
-        {data.map((d, i) => (
-          <li
-            css={{
-              display: "inline-block",
-            }}
-            key={"description-li-" + i}
-          >
-            {i > 0 && (
-              <span
-                css={{
-                  color: COLORS.neutral["300"],
-                }}
-              >
-                <Icon icon="navigate_next" />
-              </span>
-            )}
-            <Description data={d} />
-          </li>
-        ))}
+        {data.map((d, i) => {
+          return (
+            <li
+              css={{
+                display: 'inline-block'
+              }}
+              key={'description-li-' + i}
+            >
+              {i > 0 && (
+                <span
+                  css={{
+                    color: COLORS.neutral['300']
+                  }}
+                >
+                  <Icon icon='navigate_next' />
+                </span>
+              )}
+              <Description data={d} />
+            </li>
+          );
+        })}
       </ol>
     );
   }
@@ -162,43 +174,52 @@ function Description({ data }) {
       {icon && (
         <span
           css={{
-            marginRight: SPACING["2XS"],
-            color: COLORS.neutral["300"],
-            display: "flex",
-            alignItems: "center",
+            marginRight: SPACING['2XS'],
+            color: COLORS.neutral['300'],
+            display: 'flex',
+            alignItems: 'center'
           }}
         >
           <Icon icon={icon} size={19} />
         </span>
       )}
 
-      {image ? (
-        <div>
-          <span
-            css={{
-              display: "block",
-            }}
-          >
-            {text}
-          </span>
-          <img
-            src={image}
-            alt=""
-            css={{
-              maxWidth: "16rem",
-              width: "100%",
-              paddingTop: SPACING["XS"],
-            }}
-          />
-        </div>
-      ) : (
-        <React.Fragment>{text}</React.Fragment>
-      )}
+      {image
+        ? (
+          <div>
+            <span
+              css={{
+                display: 'block'
+              }}
+            >
+              {text}
+            </span>
+            <img
+              src={image}
+              alt=''
+              css={{
+                maxWidth: '16rem',
+                width: '100%',
+                paddingTop: SPACING.XS
+              }}
+            />
+          </div>
+          )
+        : (
+          <>{text}</>
+          )}
     </DescriptionItem>
   );
 }
 
-function DescriptionItem({ href, search, children }) {
+Description.propTypes = {
+  data: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object
+  ])
+};
+
+function DescriptionItem ({ href, search, children }) {
   if (href || search) {
     return (
       <DescriptionItemLink href={href} search={search}>
@@ -210,10 +231,16 @@ function DescriptionItem({ href, search, children }) {
   return children;
 }
 
-function DescriptionItemLink({ href, search, children }) {
+DescriptionItem.propTypes = {
+  href: PropTypes.string,
+  search: PropTypes.object,
+  children: PropTypes.array
+};
+
+function DescriptionItemLink ({ href, search, children }) {
   if (href) {
     return (
-      <a css={LINK_STYLES["default"]} href={href}>
+      <a css={LINK_STYLES.default} href={href}>
         {children}
       </a>
     );
@@ -222,28 +249,38 @@ function DescriptionItemLink({ href, search, children }) {
   return <SearchLink search={search}>{children}</SearchLink>;
 }
 
-function SearchLink({ children, search }) {
-  const { datastores, institution } = useSelector((state) => state);
+DescriptionItemLink.propTypes = {
+  href: PropTypes.string,
+  search: PropTypes.object,
+  children: PropTypes.array
+};
+
+function SearchLink ({ children, search }) {
+  const { datastores, institution } = useSelector((state) => {
+    return state;
+  });
   const activeDatastore = datastores.datastores.find(
-    (ds) => ds.uid === datastores.active
+    (ds) => {
+      return ds.uid === datastores.active;
+    }
   );
   const to =
-    "/" +
+    '/' +
     activeDatastore.slug +
-    "?" +
+    '?' +
     createSearchURL({
       ...search,
       institution,
-      datastoreUid: activeDatastore.uid,
+      datastoreUid: activeDatastore.uid
     });
 
   return (
     <Link
       css={{
-        textDecoration: "underline",
-        ":hover": {
-          textDecorationThickness: "2px",
-        },
+        textDecoration: 'underline',
+        ':hover': {
+          textDecorationThickness: '2px'
+        }
       }}
       to={to}
     >
@@ -252,15 +289,22 @@ function SearchLink({ children, search }) {
   );
 }
 
-function createSearchURL({ type, scope, value, institution, datastoreUid }) {
+SearchLink.propTypes = {
+  children: PropTypes.array,
+  search: PropTypes.object
+};
+
+function createSearchURL ({ type, scope, value, institution, datastoreUid }) {
   const query =
-    type === "fielded" ? `${scope}:${value}` :
-    type === "specified" ? value :
-    {};
-  const filter = type === "filtered" ? { [scope]: value } : {};
+    type === 'fielded'
+      ? `${scope}:${value}`
+      : type === 'specified'
+        ? value
+        : {};
+  const filter = type === 'filtered' ? { [scope]: value } : {};
   let library = {};
 
-  if (datastoreUid === "mirlyn") {
+  if (datastoreUid === 'mirlyn') {
     library = institution.active
       ? institution.active
       : institution.defaultInstitution;
@@ -269,6 +313,6 @@ function createSearchURL({ type, scope, value, institution, datastoreUid }) {
   return stringifySearchQueryForURL({
     query,
     filter,
-    library,
+    library
   });
 }

--- a/src/modules/reusable/index.js
+++ b/src/modules/reusable/index.js
@@ -1,15 +1,15 @@
-import Alert from "./components/Alert";
-import Button from "./components/Button";
-import Tag from "./components/Tag";
-import Modal from "./components/Modal";
-import Breadcrumb from "./components/Breadcrumb";
-import Pagination from "./components/Pagination";
-import ContextProvider from "./components/ContextProvider";
-import Metadata from "./components/Metadata";
-import Icon from "./components/Icon";
-import { Tab, TabList, Tabs, TabPanel } from "./components/Tabs";
-import { Expandable, ExpandableButton, ExpandableChildren, ExpandableProvider } from "./components/Expandable";
-import ResourceAccess from "./components/ResourceAccess";
+import Alert from './components/Alert';
+import Button from './components/Button';
+import Tag from './components/Tag';
+import Modal from './components/Modal';
+import Breadcrumb from './components/Breadcrumb';
+import Pagination from './components/Pagination';
+import ContextProvider from './components/ContextProvider';
+import Metadata from './components/Metadata';
+import Icon from './components/Icon';
+import { Tab, TabList, Tabs, TabPanel } from './components/Tabs';
+import { Expandable, ExpandableButton, ExpandableChildren, ExpandableProvider } from './components/Expandable';
+import ResourceAccess from './components/ResourceAccess';
 
 export {
   Alert,


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [LIBSEARCH-820](https://mlit.atlassian.net/browse/LIBSEARCH-820).

> UX research on the position and style for “Browse in call number list” shows the most discoverable position is in the record metadata component as a new metadata element, listing the unique LC and Dewey call numbers, one per line, each linked to Call Number Browse.

### Type of change
- [x] Text/content fix (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### This has been tested on the following browser(s)

- [x] Chrome
- [x] Safari
- [x] Firefox
- [ ] Opera

### This has been tested for Accessibility with the following:

- [x] WAVE
- [ ] Accessibility Insights
- [x] axe
- [x] Other

## Preview

![image](https://user-images.githubusercontent.com/27687379/225649167-7ff56e3c-7882-4b0d-9122-c13d7d967671.png)

