### PR TITLE
[LIBSEARCH-817] Switching from a keyword "author:last, first" search to author browse has problems

### DIFF
--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -29,7 +29,10 @@ function SearchBox ({ history, match, location }) {
     }
   );
   const [inputQuery, setInputQuery] = React.useState(query);
-  const defaultField = fields[0].uid;
+  const fieldIDs = fields.map((field) => {
+    return field.uid;
+  });
+  const defaultField = fieldIDs[0];
   const [field, setField] = React.useState(defaultField);
 
   // Set field and input when `activeDatastore` or `query` changes
@@ -38,20 +41,25 @@ function SearchBox ({ history, match, location }) {
     let getField = defaultField;
     // Set default value of input
     let getInput = query;
-    // Check if the query is a single fielded search
-    if (query && query.includes(':(') && ![' AND ', ' OR ', ' NOT '].some((operator) => {
-      return query.includes(operator);
-    })) {
-      // Get current search field uid from query
-      const currentQuery = query.slice(0, query.indexOf(':'));
-      // Check if current query exists in active datastore's field options
-      if (fields.map((field) => {
-        return field.uid;
-      }).includes(currentQuery)) {
-        // Update field to current query
-        getField = currentQuery;
-        // Remove field wrap from input value
-        getInput = query.slice((query.indexOf('(') + 1), -1);
+    // Check if the query is a single fielded search that exists in the current datastore
+    if (
+      query &&
+      ![' AND ', ' OR ', ' NOT '].some((operator) => {
+        return query.includes(operator);
+      }) &&
+      fieldIDs.some((field) => {
+        return query.startsWith(`${field}:`);
+      })
+    ) {
+      // Update field that matches query
+      getField = fieldIDs.find((field) => {
+        return query.startsWith(`${field}:`);
+      });
+      // Remove field search from query
+      getInput = getInput.replace(`${getField}:`, '');
+      // Remove parenthesis from query
+      if (getInput.startsWith('(') && getInput.endsWith(')')) {
+        getInput = getInput.slice(1, -1);
       }
     }
     // Set field value
@@ -81,13 +89,9 @@ function SearchBox ({ history, match, location }) {
 
     // Check if browse option
     const browseOption = dropdownOption.startsWith('browse_by_');
-    const browseURL = browseOption ? `/browse/${dropdownOption.slice(10)}` : '';
 
     // Set new query
     const newQuery = (browseOption || dropdownOption === defaultField) ? inputQuery : `${dropdownOption}:(${inputQuery})`;
-
-    // Check if new search
-    if (query === newQuery) return;
 
     // Set new URL
     const newURL = qs.stringify({
@@ -106,10 +110,14 @@ function SearchBox ({ history, match, location }) {
 
     // Redirect users if browse option has been submitted
     if (browseOption) {
-      window.location.href = `/${match.params.datastoreSlug}${browseURL}?${newURL}`;
-    } else {
-      history.push(`/${match.params.datastoreSlug}?${newURL}`);
+      window.location.href = `/${match.params.datastoreSlug}/browse/${dropdownOption.replace('browse_by_', '')}?${newURL}`;
     }
+
+    // Do not submit if query remains unchanged
+    if (query === newQuery) return;
+
+    // Submit new search
+    history.push(`/${match.params.datastoreSlug}?${newURL}`);
   }
 
   return (


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses [LIBSEARCH-817](https://mlit.atlassian.net/browse/LIBSEARCH-817).

> When the Catalog search box is populated with “author:last name, first name” (including the quotations), and the user switches to “Browse by author” in the drop down, several things .
> 
> 1. Start at [https://search.lib.umich.edu/catalog?library=All+libraries&query=author%3A%22Bronte%2C+Charlotte%22](https://search.lib.umich.edu/catalog?library=All+libraries&query=author%3A%22Bronte%2C+Charlotte%22)
> 2. You can't just switch to “Browse by author” because Search doesn’t recognize it as a new search

This bug exists because whenever there is was change, the program looks for `:(` in the query. If those characters do not exist, the query is then seen as a `keyword` search, and is then seen as unchanged. When the query has not changed, it will not submit a new search. The logic for returning if unchanged has been moved after checking if any of the `browse_by_` options have been selected. The field/input changes will also now allow fielded query searches that are not wrapped in parenthesis.