### PR TITLE
Updating workflows.

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Setup node
+        uses: actions/checkout@v3
+      - name: Use Node.js 16.15.1
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16.15.1
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/dockerhub-release.yaml
+++ b/.github/workflows/dockerhub-release.yaml
@@ -8,27 +8,27 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get the version
       id: tag
-      run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+      run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and push
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
         push: true
         tags: bertrama/search:${{ steps.tag.outputs.TAG }}

--- a/.github/workflows/dockerhub-unstable.yaml
+++ b/.github/workflows/dockerhub-unstable.yaml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build container image and push to DockerHub
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
         push: true
         tags: 'bertrama/search-unstable:${{ github.sha }},bertrama/search-unstable:latest'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16.15.1
 RUN mkdir -p /app/build
 WORKDIR /app
 COPY ./package.json ./package-lock.json /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.15.1
+FROM node:16
 RUN mkdir -p /app/build
 WORKDIR /app
 COPY ./package.json ./package-lock.json /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:16-alpine
+FROM node:16.15.1
 RUN mkdir -p /app/build
 WORKDIR /app
 COPY ./package.json ./package-lock.json /app/
-RUN npm install && npm cache clean --force
+RUN npm install --legacy-peer-deps && npm cache clean --force
 
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:16-alpine
 RUN mkdir -p /app/build
 WORKDIR /app
 COPY ./package.json ./package-lock.json /app/

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "develop": "npm run start",
     "eject": "react-scripts eject",
     "lint": "npx eslint src/**/*.js",
-    "reinstall": "rm -rf node_modules && npm install",
+    "reinstall": "rm -rf node_modules && npm install --legacy-peer-deps",
     "start": "DISABLE_ESLINT_PLUGIN=true REACT_APP_SPECTRUM_BASE_URL=${REACT_APP_SPECTRUM_BASE_URL:-https://search-staging.www.lib.umich.edu/spectrum} react-scripts start",
     "test": "react-scripts test --env=jsdom"
   },


### PR DESCRIPTION
# Overview
When running a GitHub action, 9 related warnings will be displayed under Annotations:
```
build
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: docker/login-action@v1, docker/build-push-action@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```
```
build
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
```
build
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
The workflows have been updated to their latest versions to help resolve these warnings.

- Node has been specified to run version `16.15.1`.
- `set-output` command has been updated.