### PR TITLE
Replacing `actions/upload-release-asset`

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,14 +26,12 @@ jobs:
       - name: Package
         run: tar -C build --transform s/./search/ -czf search-staging.tar.gz .
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./search-staging.tar.gz
-          asset_name: search-staging.tar.gz
-          asset_content_type: application/gzip
+          files: search-staging.tar.gz
 
       - name: Clean
         run: rm -rf build
@@ -46,14 +44,12 @@ jobs:
       - name: Package
         run: tar -C build --transform s/./search/ -czf search-production.tar.gz .
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./search-production.tar.gz
-          asset_name: search-production.tar.gz
-          asset_content_type: application/gzip
+          files: search-production.tar.gz
 
       - name: Clean
         run: rm -rf build
@@ -66,11 +62,9 @@ jobs:
       - name: Package
         run: tar -C build --transform s/./search/ -czf search-local.tar.gz .
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./search-local.tar.gz
-          asset_name: search-local.tar.gz
-          asset_content_type: application/gzip
+          files: search-local.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -30,7 +30,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
           files: search-staging.tar.gz
 
       - name: Clean
@@ -48,7 +47,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
           files: search-production.tar.gz
 
       - name: Clean
@@ -66,5 +64,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
           files: search-local.tar.gz


### PR DESCRIPTION
[actions/upload-release-asset](https://github.com/actions/upload-release-asset) has become an unmaintained repository, and was archived March 3, 2021. The project recommends to replace the action with [softprops/action-gh-release](https://github.com/softprops/action-gh-release). This pull request replaces the archived action with the recommended action.