### PR TITLE
Libsearch 878 fix accessibility errors and warnings part 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "prop-types": "^15.8.1",
         "qs": "^6.11.1",
         "react": "^18.2.0",
-        "react-accessible-accordion": "^5.0.0",
         "react-app-polyfill": "^3.0.0",
         "react-autosuggest": "^10.1.0",
         "react-cookie": "^4.1.1",
@@ -14101,15 +14100,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-accessible-accordion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-accessible-accordion/-/react-accessible-accordion-5.0.0.tgz",
-      "integrity": "sha512-MT2obYpTgLIIfPr9d7hEyvPB5rg8uJcHpgA83JSRlEUHvzH48+8HJPvzSs+nM+XprTugDgLfhozO5qyJpBvYRQ==",
-      "peerDependencies": {
-        "react": "^16.3.2 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.3.3 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-app-polyfill": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-3.0.0.tgz",
@@ -16496,9 +16486,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -16506,7 +16496,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "prop-types": "^15.8.1",
         "qs": "^6.11.1",
         "react": "^18.2.0",
-        "react-app-polyfill": "^3.0.0",
         "react-autosuggest": "^10.1.0",
         "react-cookie": "^4.1.1",
         "react-dom": "^18.2.0",
@@ -4825,7 +4824,8 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
@@ -12322,7 +12322,8 @@
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -13903,6 +13904,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
       "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+      "dev": true,
       "dependencies": {
         "asap": "~2.0.6"
       }
@@ -14031,6 +14033,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
       "dependencies": {
         "performance-now": "^2.1.0"
       }
@@ -14104,6 +14107,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-3.0.0.tgz",
       "integrity": "sha512-sZ41cxiU5llIB003yxxQBYrARBqe0repqPTTYBTmMqTz9szeBbE37BehCE891NZsmdZqqP+xWKdT3eo3vOzN8w==",
+      "dev": true,
       "dependencies": {
         "core-js": "^3.19.2",
         "object-assign": "^4.1.1",
@@ -17226,7 +17230,8 @@
     "node_modules/whatwg-fetch": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "prop-types": "^15.8.1",
     "qs": "^6.11.1",
     "react": "^18.2.0",
-    "react-app-polyfill": "^3.0.0",
     "react-autosuggest": "^10.1.0",
     "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "prop-types": "^15.8.1",
     "qs": "^6.11.1",
     "react": "^18.2.0",
-    "react-accessible-accordion": "^5.0.0",
     "react-app-polyfill": "^3.0.0",
     "react-autosuggest": "^10.1.0",
     "react-cookie": "^4.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
-import 'react-app-polyfill/ie11';
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
-
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import {

--- a/src/modules/core/components/Checkbox/index.js
+++ b/src/modules/core/components/Checkbox/index.js
@@ -18,7 +18,7 @@ class Checkbox extends React.Component {
       <div
         className='checkbox'
         role='checkbox'
-        aria-checked={isChecked}
+        aria-checked={!!isChecked}
         tabIndex='0'
         onClick={handleClick}
         onKeyDown={(event) => {

--- a/src/modules/getthis/components/GetThisFAQ/index.js
+++ b/src/modules/getthis/components/GetThisFAQ/index.js
@@ -1,9 +1,0 @@
-import React from 'react';
-
-const GetThisFAQ = () => {
-  return (
-    <section className='card get-this-section' />
-  );
-};
-
-export default GetThisFAQ;

--- a/src/modules/getthis/components/GetThisPage/index.js
+++ b/src/modules/getthis/components/GetThisPage/index.js
@@ -2,11 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter, Link } from 'react-router-dom';
 import { requestRecord, requestGetThis } from '../../../pride';
-import {
-  GetThisOptionList,
-  GetThisFAQ,
-  GetThisRecord
-} from '../../../getthis';
+import { GetThisOptionList, GetThisRecord } from '../../../getthis';
 import { Breadcrumb } from '../../../reusable';
 import PropTypes from 'prop-types';
 
@@ -81,7 +77,6 @@ class GetThisPage extends React.Component {
       <GetThisPageTemplate recordUid={recordUid}>
         <GetThisRecord barcode={barcode} />
         <GetThisOptionList record={record} />
-        <GetThisFAQ />
       </GetThisPageTemplate>
     );
   }

--- a/src/modules/getthis/components/GetThisRecord/index.js
+++ b/src/modules/getthis/components/GetThisRecord/index.js
@@ -6,7 +6,7 @@ import getHoldingByBarcode from '../../getHoldingByBarcode';
 import { TrimString } from '../../../core';
 import { RecordFullFormats, FullRecordPlaceholder } from '../../../records';
 import ResourceAccess from '../../../resource-acccess';
-import { COLORS, MEDIA_QUERIES, SPACING } from '../../../reusable/umich-lib-core-temp';
+import { COLORS } from '../../../reusable/umich-lib-core-temp';
 import PropTypes from 'prop-types';
 
 /*
@@ -15,18 +15,18 @@ import PropTypes from 'prop-types';
 */
 
 const StyledGetThisResourceAccessContainer = styled('div')({
-  'td:first-of-type': {
+  'td:first-of-type, th:first-of-type': {
     display: 'none'
   },
-  'th:first-of-type': {
-    display: 'none'
+  'td:first-of-type + *, th:first-of-type + *': {
+    paddingLeft: '0'
   },
   a: {
     textDecoration: 'underline'
   },
   table: {
-    tableLayout: 'auto',
-    minWidth: 'auto'
+    minWidth: 'auto',
+    tableLayout: 'auto'
   }
 });
 
@@ -45,19 +45,7 @@ function GetThisHolding ({ record, barcode }) {
       <StyledGetThisResourceAccessContainer>
         <div
           css={{
-            '[data-accordion-component="AccordionItemPanel"]': {
-              padding: `0 ${SPACING.M}`
-            },
-            [MEDIA_QUERIES.LARGESCREEN]: {
-              '[data-accordion-component="AccordionItemButton"]': {
-                paddingLeft: '3rem'
-              },
-              '[data-accordion-component="AccordionItemPanel"]': {
-                padding: `0 ${SPACING.M}`,
-                paddingLeft: '3rem'
-              },
-              borderBottom: `solid 1px ${COLORS.neutral[100]}`
-            }
+            borderBottom: `solid 1px ${COLORS.neutral[100]}`
           }}
         >
           <h3 className='visually-hidden'>Available at</h3>

--- a/src/modules/getthis/index.js
+++ b/src/modules/getthis/index.js
@@ -1,12 +1,10 @@
 import GetThisPage from './components/GetThisPage';
-import GetThisFAQ from './components/GetThisFAQ';
 import GetThisOptionList from './components/GetThisOptionList';
 import GetThisRecord from './components/GetThisRecord';
 import GetThisForm from './components/GetThisForm';
 
 export {
   GetThisPage,
-  GetThisFAQ,
   GetThisOptionList,
   GetThisRecord,
   GetThisForm

--- a/src/modules/records/components/Record/index.js
+++ b/src/modules/records/components/Record/index.js
@@ -7,7 +7,7 @@ import { getDatastoreSlugByUid } from '../../../pride';
 import { getField, getFieldValue } from '../../utilities';
 import { AddToListButton, isInList } from '../../../lists';
 import Zotero from '../Zotero';
-import { COLORS, MEDIA_QUERIES, SPACING } from '../../../reusable/umich-lib-core-temp';
+import { COLORS, SPACING } from '../../../reusable/umich-lib-core-temp';
 import ResourceAccess from '../../../resource-acccess';
 import PropTypes from 'prop-types';
 
@@ -114,19 +114,7 @@ class Record extends React.Component {
 
           <div
             css={{
-              '[data-accordion-component="AccordionItemPanel"]': {
-                padding: `0 ${SPACING.M}`
-              },
-              [MEDIA_QUERIES.LARGESCREEN]: {
-                '[data-accordion-component="AccordionItemButton"]': {
-                  paddingLeft: '3rem'
-                },
-                '[data-accordion-component="AccordionItemPanel"]': {
-                  padding: `0 ${SPACING.M}`,
-                  paddingLeft: '3rem'
-                },
-                borderBottom: `solid 1px ${COLORS.neutral[100]}`
-              }
+              borderBottom: `solid 1px ${COLORS.neutral[100]}`
             }}
           >
             <h4 className='visually-hidden'>{record.names[0]} is available at:</h4>

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -5,13 +5,7 @@ import _ from 'underscore';
 import { withRouter, Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { Breadcrumb } from '../../../reusable';
-import {
-  COLORS,
-  SEARCH_COLORS,
-  MEDIA_QUERIES,
-  SPACING
-} from '../../../reusable/umich-lib-core-temp';
-
+import { COLORS, SEARCH_COLORS } from '../../../reusable/umich-lib-core-temp';
 import { TrimString } from '../../../core';
 import { getField, getFieldValue } from '../../utilities';
 import {
@@ -163,17 +157,12 @@ class FullRecord extends React.Component {
         </div>
       );
     }
-    // For adding a blue border when added to list.
-    const inList = isInList(list, record.uid);
-    const recordClassName = inList
-      ? 'full-record-container record--highlight'
-      : 'full-record-container';
 
     return (
       <div className='container container-narrow full-record-page-container y-spacing'>
         <FullRecordBreadcrumbs datastore={datastore} />
         <GoToList list={list} datastore={datastore} />
-        <div className={recordClassName}>
+        <div className={`full-record-container ${isInList(list, record.uid) ? 'record--highlight' : ''}`}>
           <RecordFullFormats formats={record.formats} />
           <div className='record-container'>
             <div className='full-record-title-and-actions-container'>
@@ -213,18 +202,7 @@ class FullRecord extends React.Component {
 
             <div
               css={{
-                borderBottom: `solid 1px ${COLORS.neutral[100]}`,
-                '[data-accordion-component="AccordionItemPanel"]': {
-                  padding: `0 ${SPACING.M}`
-                },
-                [MEDIA_QUERIES.LARGESCREEN]: {
-                  '[data-accordion-component="AccordionItemButton"]': {
-                    paddingLeft: '3rem'
-                  },
-                  '[data-accordion-component="AccordionItemPanel"]': {
-                    paddingLeft: '3rem'
-                  }
-                }
+                borderBottom: `solid 1px ${COLORS.neutral[100]}`
               }}
             >
               <ResourceAccess record={record} />

--- a/src/modules/resource-acccess/components/holder.js
+++ b/src/modules/resource-acccess/components/holder.js
@@ -10,12 +10,6 @@ import {
 } from '../../reusable';
 import PropTypes from 'prop-types';
 
-const cellPadding = {
-  paddingTop: SPACING.XS,
-  paddingBottom: SPACING.XS,
-  paddingRight: SPACING.L
-};
-
 const notesList = (notes) => {
   if (!notes) return null;
 
@@ -60,20 +54,15 @@ export default function Holder ({
   ...rest
 }) {
   return (
-    <div
-      css={{
-        padding: `${SPACING.S} 0`
-      }}
-      {...rest}
-    >
+    <div {...rest}>
       {captionLink && (
         <p
           css={{
+            display: 'inline-block',
+            margin: '0',
             a: {
               color: COLORS.neutral['400']
-            },
-            display: 'inline-block',
-            margin: '0'
+            }
           }}
         >
           <a href={captionLink.href}>
@@ -93,10 +82,20 @@ export default function Holder ({
           >
             <table
               css={{
-                width: '100%',
                 minWidth: '24rem',
+                tableLayout: 'fixed',
                 textAlign: 'left',
-                tableLayout: 'fixed'
+                width: '100%',
+                'tr > *': {
+                  padding: '0.5rem 0',
+                  width: 'auto',
+                  '& + *': {
+                    paddingLeft: '1.5rem'
+                  },
+                  '&:nth-of-type(3):last-of-type': {
+                    width: '50%'
+                  }
+                }
               }}
             >
               <thead>
@@ -107,12 +106,9 @@ export default function Holder ({
                         scope='col'
                         key={i}
                         css={{
-                          fontWeight: '600',
-                          color: COLORS.neutral['300'],
-                          ...cellPadding,
                           borderBottom: `solid 2px ${COLORS.neutral['100']}`,
-                          width:
-                          headings.length === 3 && i === 2 ? '50%' : 'auto'
+                          color: COLORS.neutral['300'],
+                          fontWeight: '600'
                         }}
                       >
                         {heading}
@@ -163,7 +159,6 @@ function HolderRows ({ rows }) {
         <td
           colSpan={`${rows[0].length}`}
           css={{
-            ...cellPadding,
             wordBreak: 'break-word'
           }}
         >

--- a/src/modules/resource-acccess/components/holders.js
+++ b/src/modules/resource-acccess/components/holders.js
@@ -1,24 +1,10 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
-import {
-  Accordion,
-  AccordionItem,
-  AccordionItemHeading,
-  AccordionItemPanel,
-  AccordionItemButton,
-  AccordionItemState
-} from 'react-accessible-accordion';
 import Icon from '../../reusable/components/Icon';
 import HolderContainer from './holder-container';
-import { COLORS, SPACING } from '../../reusable/umich-lib-core-temp/index';
+import { COLORS } from '../../reusable/umich-lib-core-temp/index';
 import PropTypes from 'prop-types';
 
-/*
-  Holders
-    Holder
-      Holdings
-        Holding
-*/
 export default function Holders ({
   record,
   preExpandedIds,
@@ -26,45 +12,80 @@ export default function Holders ({
   context
 }) {
   return (
-    <Accordion
-      allowMultipleExpanded
-      allowZeroExpanded
-      preExpanded={preExpandedIds}
-      css={{
-        '[aria-expanded="true"][data-accordion-component]': {
-          background: COLORS.blue['100']
-        }
-      }}
-      key={record.type + record.uid}
-    >
+    <>
       {record.resourceAccess.map((data, i) => {
+        const { rows, caption, type } = data;
         return (
-          <AccordionItem uuid={createId(record, i)} key={createId(record, i)}>
-            <AccordionItemState>
-              {({ expanded }) => {
-                return (
-                  <>
-                    <AccordionItemHeading>
-                      <AccordionItemHeadingContent
-                        data={data}
-                        expanded={expanded}
-                      />
-                    </AccordionItemHeading>
-                    <AccordionItemPanel>
-                      {expanded
-                        ? (
-                          <HolderContainer context={context} {...data} />
-                          )
-                        : null}
-                    </AccordionItemPanel>
-                  </>
-                );
+          <details
+            key={createId(record, i)}
+            css={{
+              '& > *': {
+                padding: '0.75rem 1rem',
+                paddingLeft: '3rem'
+              }
+            }}
+          >
+            <summary
+              css={{
+                alignItems: 'center',
+                borderTop: `solid 1px ${COLORS.neutral['100']}`,
+                color: COLORS.neutral['300'],
+                cursor: 'pointer',
+                display: 'flex',
+                gap: '0.75rem',
+                listStyle: 'none',
+                '&::-webkit-details-marker': {
+                  display: 'none'
+                },
+                'details[open] > &': {
+                  background: COLORS.blue['100']
+                },
+                '& > *': {
+                  flexShrink: '0'
+                }
               }}
-            </AccordionItemState>
-          </AccordionItem>
+            >
+              <Icon
+                d={
+                  type === 'electronic'
+                    ? 'M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z'
+                    : 'M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z'
+                }
+                size={19}
+              />
+              <span css={{
+                flexGrow: '1',
+                flexShrink: '1'
+              }}
+              >
+                <span
+                  css={{
+                    fontWeight: '600',
+                    color: COLORS.neutral['400'],
+                    'summary:hover &': {
+                      textDecoration: 'underline'
+                    }
+                  }}
+                >
+                  {caption || 'Availability'}
+                </span>
+                &nbsp;&nbsp;&middot;&nbsp;&nbsp;{rows.length} item{rows.length > 1 ? 's' : null}
+              </span>
+              <span css={{
+                'details:not([open]) > summary > & > svg:first-of-type, details[open] > summary > & > svg:last-of-type': {
+                  display: 'none'
+                }
+              }}
+              >
+                <Icon size={24} d='M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z' />
+                <Icon size={24} d='M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z' />
+              </span>
+            </summary>
+            <HolderContainer context={context} {...data} />
+          </details>
         );
       })}
-    </Accordion>
+    </>
   );
 }
 
@@ -73,83 +94,4 @@ Holders.propTypes = {
   preExpandedIds: PropTypes.array,
   createId: PropTypes.func,
   context: PropTypes.object
-};
-
-const contentPadding = {
-  padding: `${SPACING.S} ${SPACING.M}`
-};
-
-const headingStyles = {
-  ...contentPadding,
-  borderTop: `solid 1px ${COLORS.neutral['100']}`,
-  cursor: 'pointer',
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  ':hover [data-holdings-holder-name]': {
-    borderBottom: 'solid 1px'
-  },
-  color: COLORS.neutral['300']
-};
-
-const icons = {
-  description:
-    'M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z',
-  link:
-    'M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z'
-};
-
-function getIconPath (type) {
-  switch (type) {
-    case 'electronic':
-      return icons.link;
-    default:
-      return icons.description;
-  }
-}
-
-/*
-  - Render the button to click on.
-  - And create the Google Analytics click event handler.
-*/
-function AccordionItemHeadingContent ({ data, expanded }) {
-  const { rows, caption, type } = data;
-
-  return (
-    <AccordionItemButton css={headingStyles}>
-      <span
-        css={{
-          paddingRight: SPACING.M
-        }}
-      >
-        <span css={{ paddingRight: SPACING.S }}>
-          <Icon d={getIconPath(type)} css={{ marginTop: '-4px' }} size={19} />
-        </span>
-        <span
-          data-holdings-holder-name
-          css={{ fontWeight: '600', color: COLORS.neutral['400'] }}
-        >
-          {caption || 'Availability'}
-        </span>
-        <span css={{ padding: `0 ${SPACING.XS}` }}>·</span>
-        <span>
-          {rows.length} item{rows.length > 1 ? 's' : null}
-        </span>
-      </span>
-      <span>
-        {expanded
-          ? (
-            <Icon size={24} d='M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z' />
-            )
-          : (
-            <Icon size={24} d='M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z' />
-            )}
-      </span>
-    </AccordionItemButton>
-  );
-}
-
-AccordionItemHeadingContent.propTypes = {
-  data: PropTypes.object,
-  expanded: PropTypes.bool
 };

--- a/src/modules/resource-acccess/components/holding.js
+++ b/src/modules/resource-acccess/components/holding.js
@@ -1,38 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { SPACING, INTENT_COLORS } from '../../reusable/umich-lib-core-temp';
+import { INTENT_COLORS } from '../../reusable/umich-lib-core-temp';
 import { Icon, Button } from '../../reusable';
 import PropTypes from 'prop-types';
-
-function RenderAnchor ({ data }) {
-  /*
-    Rendered Anchors go to
-    - an internal Get This page, or
-    - a full record page.
-  */
-  let to;
-
-  if (data.to.action === 'get-this') {
-    to = `/catalog/record/${data.to.record}/get-this/${data.to.barcode}` +
-      `${document.location.search}`;
-  } else {
-    to = `/catalog/record/${data.to.record}` +
-      `${document.location.search}`;
-  }
-
-  return (
-    <Link
-      to={to}
-    >
-      {data.text}
-    </Link>
-  );
-}
-
-RenderAnchor.propTypes = {
-  data: PropTypes.object
-};
 
 export default function Holding ({ holding }) {
   return (
@@ -41,9 +12,6 @@ export default function Holding ({ holding }) {
         return (
           <td
             css={{
-              paddingTop: SPACING.XS,
-              paddingBottom: SPACING.XS,
-              paddingRight: SPACING.L,
               color: INTENT_COLORS[cell.intent]
             }}
             key={i}
@@ -52,9 +20,9 @@ export default function Holding ({ holding }) {
               cell={cell}
               renderAnchor={(data) => {
                 return (
-                  <RenderAnchor
-                    data={data}
-                  />
+                  <Link to={`/catalog/record/${data.to.record}${data.to.action === 'get-this' ? `/get-this/${data.to.barcode}` : ''}${document.location.search}`}>
+                    {data.text}
+                  </Link>
                 );
               }}
             />
@@ -119,9 +87,7 @@ class TrimCellText extends React.Component {
     // Only trimming past trim text at, so user don't show all
     // for just a few more chars.
     if (text.length <= trimTextAt + 60) {
-      return (
-        <>{text}</>
-      );
+      return text;
     }
 
     // When text is longer than the trim text at length.
@@ -138,7 +104,8 @@ class TrimCellText extends React.Component {
           onClick={() => {
             return this.setState({ expanded: !isExpanded });
           }}
-        >{buttonText}
+        >
+          {buttonText}
         </Button>
       </>
     );

--- a/src/modules/resource-acccess/components/resource-access-container.js
+++ b/src/modules/resource-acccess/components/resource-access-container.js
@@ -59,10 +59,7 @@ ResourceAccess.propTypes = {
   context: PropTypes.object
 };
 
-/*
-  Create a list of uuids that should be Accordion preExpanded'ed
-  Docs: https://www.npmjs.com/package/react-accessible-accordion#preexpanded-string--optional--default--
-*/
+// Create a list of uuids for details to be opened by default
 function preExpandedIds (record) {
   return record.resourceAccess.reduce((acc, item, index) => {
     if (item.preExpanded) {


### PR DESCRIPTION
# Overview
An [accessibility evaluation](https://docs.google.com/document/d/1LiRYT1Q_eaN4mJuOb70QIVHKemx4khs7cV19JCHynBY/edit?usp=sharing) was done on Search. This pull request resolves the violations and warnings that were found using the `react-accessible-accordion` dependency, and other remaining finds through accessibility extensions. All components using `react-accessible-accordion` have been replaced using the native HTML `details` element.

This pull request closes [LIBSEARCH-878](https://mlit.atlassian.net/browse/LIBSEARCH-878).

## Anything else?
### GetThisFAQ
`GetThisFAQ` has been removed. No information was being provided to the component, nor the component had the capability of printing information. The component resulted in displaying an empty box.

### `react-app-polyfill`
According to Google Analytics, Internet Explorer users make up <0.1% of the site's traffic. This dependency has been uninstalled.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Go through the site to see if anything is broken.
- Can you open/close the accordions relating to holdings and filters?
