### PR TITLE
Adding support for previewEligible

### DIFF
--- a/src/modules/records/components/RecordPreview/index.js
+++ b/src/modules/records/components/RecordPreview/index.js
@@ -68,55 +68,47 @@ Header.propTypes = {
 };
 
 const Footer = ({ record, datastoreUid }) => {
-  // No access/holding options for Mirlyn for preview records.
-  if (datastoreUid === 'mirlyn' || datastoreUid === 'website') {
+  // No access/holding options or are Catalog or Guides and More datastores.
+  if (['mirlyn', 'website'].includes(datastoreUid) || !(record.resourceAccess && record.resourceAccess[0])) {
     return null;
   }
 
   const outage = getFieldValue(getField(record.fields, 'outage'))[0];
 
-  if (record.resourceAccess && record.resourceAccess[0]) {
-    return (
-      <>
-        {outage && (
+  return (
+    <>
+      {outage && (
+        <p
+          style={{
+            color: INTENT_COLORS.error,
+            marginBottom: '0',
+            marginTop: '0.5rem'
+          }}
+        >
+          <Icon icon='warning' /> {outage}
+        </p>
+      )}
+      {record.resourceAccess[0].rows.map((row, index) => {
+        const accessCell = row[0];
+        if (!accessCell?.previewEligible) {
+          return null;
+        }
+        return (
           <p
+            className='record-preview-link'
             style={{
-              color: INTENT_COLORS.error,
-              marginBottom: '0',
-              marginTop: '0.5rem'
+              marginBottom: '0'
             }}
+            key={record.uid + '-resource-' + index}
           >
-            <Icon icon='warning' /> {outage}
+            <a href={accessCell.href}>
+              {accessCell.text}
+            </a>
           </p>
-        )}
-        {record.resourceAccess[0].rows.map((row) => {
-          const accessCell = row[0];
-          if (accessCell && accessCell.previewEligible) {
-            return (
-              <p
-                className='record-preview-link'
-                style={{
-                  marginBottom: '0'
-                }}
-                key={accessCell.href}
-              >
-                <a href={accessCell.href}>
-                  {accessCell.text}
-                </a>
-              </p>
-            );
-          } else {
-            return null;
-          }
-        })}
-      </>
-    );
-  }
-
-  // TODO
-  // Add "Go to <thing>" here with resource access component.
-
-  return null;
+        );
+      })}
+    </>
+  );
 };
 
 Footer.propTypes = {

--- a/src/modules/records/components/RecordPreview/index.js
+++ b/src/modules/records/components/RecordPreview/index.js
@@ -76,7 +76,6 @@ const Footer = ({ record, datastoreUid }) => {
   const outage = getFieldValue(getField(record.fields, 'outage'))[0];
 
   if (record.resourceAccess && record.resourceAccess[0]) {
-    const accessCell = record.resourceAccess[0].rows[0][0];
     return (
       <>
         {outage && (
@@ -90,16 +89,26 @@ const Footer = ({ record, datastoreUid }) => {
             <Icon icon='warning' /> {outage}
           </p>
         )}
-        <p
-          className='record-preview-link'
-          style={{
-            marginBottom: '0'
-          }}
-        >
-          <a href={accessCell.href}>
-            {accessCell.text}
-          </a>
-        </p>
+        {record.resourceAccess[0].rows.map((row) => {
+          const accessCell = row[0];
+          if (accessCell && accessCell.previewEligible) {
+            return (
+              <p
+                className='record-preview-link'
+                style={{
+                  marginBottom: '0'
+                }}
+                key={accessCell.href}
+              >
+                <a href={accessCell.href}>
+                  {accessCell.text}
+                </a>
+              </p>
+            );
+          } else {
+            return null;
+          }
+        })}
       </>
     );
   }

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -1871,7 +1871,6 @@ body {
 }
 
 .record-preview-link {
-  display: inline-block;
   margin-top: 0.5rem;
 }
 

--- a/src/stylesheets/search/_record-preview.scss
+++ b/src/stylesheets/search/_record-preview.scss
@@ -35,7 +35,6 @@
 }
 
 .record-preview-link {
-  display: inline-block;
   margin-top: 0.5rem;
   text-decoration: underline;
 }


### PR DESCRIPTION
Adding a property in cells for links under resourceAccess data to indicate whether the link is eligible for being shown in preview renderings.

Removing the `display: inline-block` on the record-preview-link `<p>` tag.

# Overview

We are adding a second link to the preview view of articles results.  Previously, preview views only showed the first link available, however, we would like to show multiple links sometimes.  Online journals already has multiple links so we can't just render every link in the list.

This pull request adds final details to [LIBSEARCH-889](https://mlit.atlassian.net/browse/LIBSEARCH-889).

## Testing
List instructions on how to test the pull request. Some examples:

- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [ ] Safari
  - [ ] Edge
- Run accessibility tests:
  - [ ] WAVE
  - [ ] ARC Toolkit
  - [ ] axe DevTools
