### PR TITLE
Bug: Alert will not show if `status.status_code` is undefined.

### DIFF
--- a/src/modules/lists/components/ActionStatusMessage/index.js
+++ b/src/modules/lists/components/ActionStatusMessage/index.js
@@ -1,39 +1,38 @@
-import React, { Component } from 'react';
-import { Alert } from '../../../reusable';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-class ActionStatusMessage extends Component {
-  render () {
-    const { status, action } = this.props;
+function ActionStatusMessage (props) {
+  const { status, action } = props;
 
-    if (!status) {
-      return null;
-    }
+  if (!status) {
+    return null;
+  }
 
-    let alertType = 'warning';
-    let alertMessage = "We're sorry. Something went wrong. Please use <a href='https://www.lib.umich.edu/ask-librarian'>Ask a Librarian</a> for help.";
+  let alertType = 'warning';
+  let alertMessage = "We're sorry. Something went wrong. Please use <a href='https://www.lib.umich.edu/ask-librarian'>Ask a Librarian</a> for help.";
 
-    if (status.status_code === 'action.response.success') {
+  if (status.status_code?.startsWith('action.response.')) {
+    const statusCode = status.status_code;
+    if (statusCode.endsWith('success')) {
       alertType = 'success';
       alertMessage = `${action.name} successfully sent.`;
     }
-
-    if (status.status_code.startsWith('action.response.invalid.')) {
+    if (statusCode.includes('invalid.')) {
       alertType = 'error';
-      if (status.status_code.endsWith('email')) {
+      if (statusCode.endsWith('email')) {
         alertMessage = 'Please enter a valid email address (e.g. uniqname@umich.edu)';
       }
-      if (status.status_code.endsWith('number')) {
+      if (statusCode.endsWith('number')) {
         alertMessage = 'Please enter a valid 10-digit phone number (e.g. 000-123-5555)';
       }
     }
-
-    return (
-      <Alert type={alertType} className='u-margin-top-1'>
-        <span dangerouslySetInnerHTML={{ __html: alertMessage }} />
-      </Alert>
-    );
   }
+
+  return (
+    <div className={'alert alert-inner alert--' + alertType}>
+      <span dangerouslySetInnerHTML={{ __html: alertMessage }} />
+    </div>
+  );
 }
 
 ActionStatusMessage.propTypes = {


### PR DESCRIPTION
# Overview
When emailing a record through the `Actions` list, if there is a `status` but the `status.status_code` is `undefined`, it would throw a `console.error` and make the page go blank. That was because there was a check to see if the undefined status code had a certain string. This was found out when `/spectrum/email` was throwing a `500` error.

A check has been added to see if `status.status_code` exists. An extra check has been added to see if it begins with `'action.response.'`.

## Anything else?
`ActionStatusMessage` has been converted to a functional component, to follow today's [React practices](https://react.dev/learn/your-first-component).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Get the site locally up and running:
  - Build the branch:
    ```
    npm run build:dev
    ```
  - Copy the build over to your local `spectrum` repository:
  ```
  cp ../search/search.local.tar.gz ./ 
  gtar -xzf search.local.tar.gz -C public --transform=s%search/index.html%search/app.html% --strip-components=1 
  ```
  - Build `spectrum`:
    ```
    docker-compose up --build --no-start
    ```
  - Install `spectrum`:
    ```
    docker-compose run --rm web bundle install
    ```
  - Connect to VPN and run `spectrum`:
    ```
    docker-compose up
    ```
  - Go to [the site](http://localhost:3000/everything) and pull up a record with the `Actions` list and try and send an email.
    - Do you get a blank page?
    - Does an alert appear?
