### PR TITLE
Bug: Zotero metadata restoration

### DIFF
--- a/src/modules/records/components/Zotero/index.js
+++ b/src/modules/records/components/Zotero/index.js
@@ -44,7 +44,7 @@ function Zotero ({ record }) {
 
   // Create COinS
   return (
-    <span className='Z3988' />
+    <span title={z3988} className='Z3988' />
   );
 }
 

--- a/src/modules/records/components/Zotero/index.js
+++ b/src/modules/records/components/Zotero/index.js
@@ -43,6 +43,9 @@ function Zotero ({ record }) {
   }
 
   // Create COinS
+  // Accessiblity note: `title` is not a compatible attribute with `span`
+  // as it is a non-interactive element. Unfortunately this is how OpenURL COinS are expected to be placed:
+  // https://web.archive.org/web/20170424223448/http://ocoins.info/
   return (
     <span title={z3988} className='Z3988' />
   );


### PR DESCRIPTION
# Overview
Back in May, the `title` attribute in the `Zotero` component [was removed to resolve accessibility issues](https://github.com/mlibrary/search/commit/4d714c7fb437ba8b3711dc812a559ce79ea23896). Doing this prevents software such as Zotero from reading the citation metadata. The attribute has been restored, along with an accessibility note.
