### PR TITLE
[LIBSEARCH-926] Deploy Browse as a full service (UI)

### DIFF
--- a/src/modules/search/components/SearchByOptions/index.js
+++ b/src/modules/search/components/SearchByOptions/index.js
@@ -36,7 +36,7 @@ const SearchByOptions = ({ activeDatastore, fields }) => {
       <optgroup label='Search by'>
         {listOptions(searchByOptions)}
       </optgroup>
-      <optgroup label='Browse by [BETA]'>
+      <optgroup label='Browse by'>
         {listOptions(browseByOptions)}
       </optgroup>
     </>


### PR DESCRIPTION
# Overview
Catalog Browse is officially out of beta! This pull request removes everything beta related.

This pull request resolves [LIBSEARCH-926](https://mlit.atlassian.net/browse/LIBSEARCH-926).

## Testing
- Run the tests to make sure they pass (`npm run test`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Load up [the site](http://localhost:3000/everything) and check the dropdown. Has `[BETA]` been removed?
