### PR TITLE
Bug: Browse redirect has brief 404

### DIFF
--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -107,17 +107,22 @@ function SearchBox ({ history, match, location }) {
       format: 'RFC1738'
     });
 
-    const urlLocation = `/${match.params.datastoreSlug}${browseOption ? `/browse/${dropdownOption.replace('browse_by_', '')}` : ''}?${newURL}`;
-
-    // If not browsing
-    if (!browseOption) {
+    // Redirect users if browse option has been submitted
+    if (browseOption) {
+      let href = 'https://browse.workshop.search.lib.umich.edu';
+      if (window.location.hostname === 'search.lib.umich.edu') {
+        href = `/${match.params.datastoreSlug}/browse`;
+      }
+      if (window.location.hostname === 'localhost') {
+        href = 'http://localhost:4567';
+      }
+      window.location.href = `${href}/${dropdownOption.replace('browse_by_', '')}?${newURL}`;
+    } else {
       // Do not submit if query remains unchanged
       if (query === newQuery) return;
       // Submit new search
-      history.push(urlLocation);
+      history.push(`/${match.params.datastoreSlug}?${newURL}`);
     }
-
-    window.location.href = urlLocation;
   }
 
   return (

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -109,16 +109,15 @@ function SearchBox ({ history, match, location }) {
 
     const urlLocation = `/${match.params.datastoreSlug}${browseOption ? `/browse/${dropdownOption.replace('browse_by_', '')}` : ''}?${newURL}`;
 
-    // Redirect users if browse option has been submitted
-    if (browseOption) {
-      window.location.href = urlLocation;
+    // If not browsing
+    if (!browseOption) {
+      // Do not submit if query remains unchanged
+      if (query === newQuery) return;
+      // Submit new search
+      history.push(urlLocation);
     }
 
-    // Do not submit if query remains unchanged
-    if (query === newQuery) return;
-
-    // Submit new search
-    history.push(urlLocation);
+    window.location.href = urlLocation;
   }
 
   return (


### PR DESCRIPTION
# Overview
When going from Search to Catalog Browse, viewers briefly face a 404 page before being redirected. This pull request wraps the logic in an `if/else` statement, and also updates the location based on the current `hostname`.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- In the list of search options, select one under `Browse by`, and submit a search.
  - Do you encounter a 404 page?
  - Are you taken to the correct Catalog Browse page?
  - Does Search work fine everywhere else?
