### PR TITLE
Replacing `servce_type` and `duration` with `summary`.

### DIFF
--- a/src/modules/getthis/components/GetThisOption/index.js
+++ b/src/modules/getthis/components/GetThisOption/index.js
@@ -13,7 +13,10 @@ function GetThisOption ({ option }) {
   return (
     <details className='get-this-option' ref={detailsRef}>
       <summary className='get-this-option-summary'>
-        <h3 className='get-this-option-heading'><span className='get-this-option-heading-text'>{option.label}</span><span className='get-this-option-subheading'>{option.service_type && (<span> {option.service_type} </span>)}({option.duration})</span></h3>
+        <h3 className='get-this-option-heading'>
+          <span className='get-this-option-heading-text'>{option.label}</span>
+          <span className='get-this-option-subheading'>{option.summary}</span>
+        </h3>
       </summary>
 
       <div className='get-this-option-details-container'>


### PR DESCRIPTION
# Overview
`summary` has been [added to Spectrum](https://github.com/mlibrary/spectrum/pull/166) to replace the existing `service_type` and `duration` properties. When this is live, the next step would be to investigate and see if the two previous properties are used elsewhere and can be safely removed.

This pull request closes [LIBSEARCH-936](https://mlit.atlassian.net/browse/LIBSEARCH-936).

## DO NOT MERGE UNTIL SPECTRUM IS LIVE

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Start the site and find an item that is available through Get This. Check and see if the content has been updated. Check the site and see if anything else is broken.
