### PR TITLE
Bug: Adding fielded search links along side `browse` links.

### DIFF
--- a/src/modules/reusable/components/Metadata/index.js
+++ b/src/modules/reusable/components/Metadata/index.js
@@ -256,7 +256,7 @@ function DescriptionItemLink ({ href, search, browse, children }) {
   if (browse) {
     return (
       <span>
-        {children}
+        <SearchLink search={search}>{children}</SearchLink>
         <Anchor
           css={{
             color: COLORS.neutral['300'],


### PR DESCRIPTION
# Overview
Second browse links have been launched. As a result, the fielded search links disappeared. This pull request brings them back.

Before:
![image](https://github.com/mlibrary/search/assets/27687379/cb8b4c9c-4625-436b-b071-1dc2c75d440c)

After:
![Screenshot 2024-02-14 at 9 57 58 AM](https://github.com/mlibrary/search/assets/27687379/d0dd6334-6d49-4978-b065-93d00a3db260)

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check a [full record](http://localhost:3000/catalog/record/990134893780106381?query=herbert%2C+frank&library=All+libraries) to see if both fielded and browse second links appear, and are navigable.
