### PR TITLE
Remove remaining `service_type`

### DIFF
--- a/src/modules/getthis/components/GetThisOption/index.js
+++ b/src/modules/getthis/components/GetThisOption/index.js
@@ -3,10 +3,6 @@ import GetThisFindIt from '../GetThisFindIt';
 import { GetThisForm } from '../../../getthis';
 import PropTypes from 'prop-types';
 
-const createMarkup = (html) => {
-  return { __html: html };
-};
-
 function GetThisOption ({ option }) {
   const detailsRef = useRef(null);
 
@@ -22,13 +18,7 @@ function GetThisOption ({ option }) {
       <div className='get-this-option-details-container'>
         <div className='get-this-option-left-half'>
           {option.form
-            ? (
-              <>{option.orientation && (
-                <div dangerouslySetInnerHTML={createMarkup(option.orientation)} />
-              )}
-                <GetThisForm label={option.label} form={option.form} />
-              </>
-              )
+            ? <GetThisForm label={option.label} form={option.form} />
             : (
               <>
                 {option.label === 'Find it in the library' && (
@@ -48,7 +38,7 @@ function GetThisOption ({ option }) {
                 <ul className='get-this-policies-list'>
                   {option.description.content.map((policy, key) => {
                     return (
-                      <li key={key} dangerouslySetInnerHTML={createMarkup(policy)} />
+                      <li key={key} dangerouslySetInnerHTML={{ __html: policy }} />
                     );
                   })}
                 </ul>

--- a/src/modules/getthis/components/GetThisOption/index.js
+++ b/src/modules/getthis/components/GetThisOption/index.js
@@ -20,24 +20,23 @@ function GetThisOption ({ option }) {
       </summary>
 
       <div className='get-this-option-details-container'>
-        {option.form
-          ? (
-            <div className='get-this-option-left-half'>
-              {option.orientation && (
+        <div className='get-this-option-left-half'>
+          {option.form
+            ? (
+              <>{option.orientation && (
                 <div dangerouslySetInnerHTML={createMarkup(option.orientation)} />
               )}
-              <GetThisForm label={option.label} form={option.form} />
-            </div>
-            )
-          : (
-            <>
-              {option.service_type === 'Self Service' && (
-                <div className='get-this-option-left-half'>
+                <GetThisForm label={option.label} form={option.form} />
+              </>
+              )
+            : (
+              <>
+                {option.label === 'Find it in the library' && (
                   <GetThisFindIt />
-                </div>
+                )}
+              </>
               )}
-            </>
-            )}
+        </div>
 
         {option.description && (
           <div className='get-this-option-right-half'>

--- a/src/modules/getthis/components/GetThisOption/index.js
+++ b/src/modules/getthis/components/GetThisOption/index.js
@@ -18,7 +18,12 @@ function GetThisOption ({ option }) {
       <div className='get-this-option-details-container'>
         <div className='get-this-option-column'>
           {option.form
-            ? <GetThisForm label={option.label} form={option.form} />
+            ? (
+              <>
+                {option.orientation && <div dangerouslySetInnerHTML={{ __html: option.orientation }} />}
+                <GetThisForm label={option.label} form={option.form} />
+              </>
+              )
             : option.label === 'Find it in the library' && <GetThisFindIt />}
         </div>
 

--- a/src/modules/getthis/components/GetThisOption/index.js
+++ b/src/modules/getthis/components/GetThisOption/index.js
@@ -16,34 +16,26 @@ function GetThisOption ({ option }) {
       </summary>
 
       <div className='get-this-option-details-container'>
-        <div className='get-this-option-left-half'>
+        <div className='get-this-option-column'>
           {option.form
             ? <GetThisForm label={option.label} form={option.form} />
-            : (
-              <>
-                {option.label === 'Find it in the library' && (
-                  <GetThisFindIt />
-                )}
-              </>
-              )}
+            : option.label === 'Find it in the library' && <GetThisFindIt />}
         </div>
 
         {option.description && (
-          <div className='get-this-option-right-half'>
-            <div className='get-this-policies-container'>
-              {option.description.heading && (
-                <h4 className='get-this-policies-heading'>{option.description.heading}</h4>
-              )}
-              {option.description.content && (
-                <ul className='get-this-policies-list'>
-                  {option.description.content.map((policy, key) => {
-                    return (
-                      <li key={key} dangerouslySetInnerHTML={{ __html: policy }} />
-                    );
-                  })}
-                </ul>
-              )}
-            </div>
+          <div className='get-this-option-column'>
+            {option.description.heading && (
+              <h4 className='get-this-policies-heading'>{option.description.heading}</h4>
+            )}
+            {option.description.content && (
+              <ul className='get-this-policies-list'>
+                {option.description.content.map((policy, key) => {
+                  return (
+                    <li key={key} dangerouslySetInnerHTML={{ __html: policy }} />
+                  );
+                })}
+              </ul>
+            )}
           </div>
         )}
       </div>

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -2830,25 +2830,15 @@ input.multiselect-search {
 @media (min-width: 820px) {
   .get-this-option-details-container {
     display: flex;
-    padding: 0;
   }
 
-  .get-this-option-left-half,
-  .get-this-option-right-half {
-    padding: 1rem 1.5rem;
-  }
-
-  .get-this-option-left-half {
-    flex: 1;
-    padding-right: 0;
-  }
-
-  .get-this-option-right-half {
+  .get-this-option-column:not(:empty) {
     flex: 1;
   }
 
-  .get-this-policies-container {
+  .get-this-option-column:not(:empty) + .get-this-option-column {
     border-left: solid 2px #CCC;
+    margin-left: 1.5rem;
     padding-left: 1rem;
   }
 }


### PR DESCRIPTION
# Overview
With `service_type` and `duration` being removed from Spectrum, `service_type` will no longer be defined, so it has been removed.

## Anything else?
`GetThisOption` has been cleaned up and simplified.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Select a `Get This` item and check to see if anything is broken.
