### PR TITLE
Making `Zotero` pass accessibility tests.

### DIFF
--- a/src/modules/records/components/Zotero/index.js
+++ b/src/modules/records/components/Zotero/index.js
@@ -15,7 +15,8 @@ import PropTypes from 'prop-types';
   Solution
 
   Use ContextObjects in Spans
-  https://en.wikipedia.org/wiki/COinS
+  - https://en.wikipedia.org/wiki/COinS
+  - https://web.archive.org/web/20170424223448/http://ocoins.info/
 
   And tell Zotero COinS was created.
 */
@@ -43,11 +44,8 @@ function Zotero ({ record }) {
   }
 
   // Create COinS
-  // Accessiblity note: `title` is not a compatible attribute with `span`
-  // as it is a non-interactive element. Unfortunately this is how OpenURL COinS are expected to be placed:
-  // https://web.archive.org/web/20170424223448/http://ocoins.info/
   return (
-    <span title={z3988} className='Z3988' />
+    <span title={z3988} className='Z3988' tabIndex='-1' />
   );
 }
 


### PR DESCRIPTION
# Overview
`title` was not a compatible attribute with `span` as it was a non-interactive element. A work-around this warning was to add `tab-index="-1"` to the element.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Take a look at [a record in full view](http://localhost:3000/catalog/record/11101952588?library=All+libraries&query=test). Do you still see the Zotero information? Does it match what is on [the live site](https://search.lib.umich.edu/catalog/record/11101952588?library=All+libraries&query=test)?
