### PR TITLE
`Pride.FieldTree.parseField` to `prideParseField`.

### DIFF
--- a/src/modules/pride/index.js
+++ b/src/modules/pride/index.js
@@ -10,6 +10,7 @@ import {
   requestRecord,
   isValidURLSearchQuery,
   stringifySearchQueryForURL,
+  prideParseField,
   parseField,
   isFieldASearchLink,
   requestGetThis
@@ -34,6 +35,7 @@ export {
   requestRecord,
   isValidURLSearchQuery,
   stringifySearchQueryForURL,
+  prideParseField,
   parseField,
   isFieldASearchLink,
   requestGetThis,

--- a/src/modules/pride/setup.js
+++ b/src/modules/pride/setup.js
@@ -31,7 +31,8 @@ import { addFilters, clearFilters, setFilterGroupOrder } from '../filters';
 import {
   getDatastoreSlug,
   getDatastoreName,
-  getDatastoreUidBySlug
+  getDatastoreUidBySlug,
+  prideParseField
 } from './utils';
 
 import { setDefaultInstitution } from '../institution';
@@ -359,7 +360,7 @@ const runSearch = () => {
   if (query === '*') {
     fieldTree = {}; // search all
   } else {
-    fieldTree = Pride.FieldTree.parseField('all_fields', query);
+    fieldTree = prideParseField('all_fields', query);
   }
 
   // Inject library/institution filter with facets.

--- a/src/modules/pride/utils.js
+++ b/src/modules/pride/utils.js
@@ -253,12 +253,25 @@ const stringifySearchQueryForURL = ({ query, filter, library, page, sort }) => {
   return SearchQueryString;
 };
 
+// Code originally Pride.FieldTree.parseField
+const prideParseField = (fieldName, content) => {
+  if (!content) {
+    return {};
+  }
+
+  try {
+    return Pride.Parser.parse(content, { defaultFieldName: fieldName });
+  } catch (error) {
+    return new Pride.FieldTree.Raw(content);
+  }
+};
+
 const parseField = ({ defaultFieldName, stringToParse }) => {
   if (!stringToParse) {
     return false;
   }
 
-  return Pride.FieldTree.parseField(defaultFieldName, stringToParse);
+  return prideParseField(defaultFieldName, stringToParse);
 };
 
 const isFieldASearchLink = ({ fieldUid, datastoreUid }) => {
@@ -287,6 +300,7 @@ export {
   requestRecord,
   isValidURLSearchQuery,
   stringifySearchQueryForURL,
+  prideParseField,
   parseField,
   isFieldASearchLink,
   requestGetThis


### PR DESCRIPTION
# Overview
`Pride.FieldTree.parseField` was only ever used in Search. Instead of storing the logic in Pride, it has been moved over into a function called `prideParseField`.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Poke around the site and see if anything is broken.
