### PR TITLE
`history` and `react-router-update` - Part 1

### DIFF
--- a/src/modules/browse/components/BrowseAtoZ/index.js
+++ b/src/modules/browse/components/BrowseAtoZ/index.js
@@ -1,22 +1,25 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import qs from 'qs';
 import { Anchor } from '../../../reusable';
-import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
 
-function BrowseAtoZ (props) {
+function BrowseAtoZ () {
+  const { datastoreSlug } = useParams();
   const createBrowseTo = ({ query, filter }) => {
-    const queryString = qs.stringify({
-      query,
-      filter,
-      sort: 'title_asc'
-    }, {
-      arrayFormat: 'repeat',
-      encodeValuesOnly: true,
-      allowDots: true,
-      format: 'RFC1738'
-    });
-    return `/${props.match.params.datastoreSlug}?${queryString}`;
+    const queryString = qs.stringify(
+      {
+        query,
+        filter,
+        sort: 'title_asc'
+      },
+      {
+        arrayFormat: 'repeat',
+        encodeValuesOnly: true,
+        allowDots: true,
+        format: 'RFC1738'
+      }
+    );
+    return `/${datastoreSlug}?${queryString}`;
   };
 
   return (
@@ -40,8 +43,4 @@ function BrowseAtoZ (props) {
   );
 }
 
-BrowseAtoZ.propTypes = {
-  match: PropTypes.object
-};
-
-export default withRouter(BrowseAtoZ);
+export default BrowseAtoZ;

--- a/src/modules/getthis/components/GetThisPage/index.js
+++ b/src/modules/getthis/components/GetThisPage/index.js
@@ -6,34 +6,6 @@ import { GetThisOptionList, GetThisRecord } from '../../../getthis';
 import { Breadcrumb } from '../../../reusable';
 import PropTypes from 'prop-types';
 
-function GetThisPageTemplate ({ recordUid, children }) {
-  return (
-    <article className='container container-narrow'>
-      <div className='u-margin-top-1'>
-        <Breadcrumb
-          items={[
-            { text: 'Catalog', to: `/catalog${document.location.search}` },
-            { text: 'Record', to: `/catalog/record/${recordUid}${document.location.search}` },
-            { text: 'Get This' }
-          ]}
-        />
-      </div>
-      <section>
-        <h1 className='heading-xlarge' id='maincontent' tabIndex='-1'>Get This</h1>
-      </section>
-      {children}
-    </article>
-  );
-}
-
-GetThisPageTemplate.propTypes = {
-  recordUid: PropTypes.string,
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
-  ])
-};
-
 class GetThisPage extends React.Component {
   componentDidMount () {
     const { recordUid, barcode } = this.props.match.params;
@@ -55,21 +27,37 @@ class GetThisPage extends React.Component {
     const { record } = this.props;
     const { barcode, recordUid } = this.props.match.params;
 
-    if (record?.fields?.length === 0 && record?.names?.length === 0) {
-      return (
-        <GetThisPageTemplate>
-          <div className='alert'>
-            <p><span className='strong'>Error:</span> Unable to find this record.</p>
-          </div>
-        </GetThisPageTemplate>
-      );
-    }
-
     return (
-      <GetThisPageTemplate recordUid={recordUid}>
-        <GetThisRecord barcode={barcode} />
-        <GetThisOptionList record={record} />
-      </GetThisPageTemplate>
+      <article className='container container-narrow'>
+        <div className='u-margin-top-1'>
+          <Breadcrumb
+            items={[
+              { text: 'Catalog', to: `/catalog${document.location.search}` },
+              { text: 'Record', to: `/catalog/record/${recordUid}${document.location.search}` },
+              { text: 'Get This' }
+            ]}
+          />
+        </div>
+        <section>
+          <h1 className='heading-xlarge' id='maincontent' tabIndex='-1'>Get This</h1>
+        </section>
+        {(() => {
+          if (record?.fields?.length === 0 && record?.names?.length === 0) {
+            return (
+              <div className='alert'>
+                <p><span className='strong'>Error:</span> Unable to find this record.</p>
+              </div>
+            );
+          }
+
+          return (
+            <>
+              <GetThisRecord barcode={barcode} />
+              <GetThisOptionList record={record} />
+            </>
+          );
+        })()}
+      </article>
     );
   }
 }

--- a/src/modules/getthis/components/GetThisPage/index.js
+++ b/src/modules/getthis/components/GetThisPage/index.js
@@ -6,29 +6,24 @@ import { GetThisOptionList, GetThisRecord } from '../../../getthis';
 import { Breadcrumb } from '../../../reusable';
 import PropTypes from 'prop-types';
 
-class GetThisPageTemplate extends React.Component {
-  render () {
-    const { recordUid } = this.props;
-
-    return (
-      <article className='container container-narrow'>
-        <div className='u-margin-top-1'>
-          <Breadcrumb
-            items={[
-              { text: 'Catalog', to: `/catalog${document.location.search}` },
-              { text: 'Record', to: `/catalog/record/${recordUid}${document.location.search}` },
-              { text: 'Get This' }
-            ]}
-          />
-        </div>
-        <section>
-          <h1 className='heading-xlarge' id='maincontent' tabIndex='-1'>Get This</h1>
-        </section>
-
-        {this.props.children}
-      </article>
-    );
-  }
+function GetThisPageTemplate ({ recordUid, children }) {
+  return (
+    <article className='container container-narrow'>
+      <div className='u-margin-top-1'>
+        <Breadcrumb
+          items={[
+            { text: 'Catalog', to: `/catalog${document.location.search}` },
+            { text: 'Record', to: `/catalog/record/${recordUid}${document.location.search}` },
+            { text: 'Get This' }
+          ]}
+        />
+      </div>
+      <section>
+        <h1 className='heading-xlarge' id='maincontent' tabIndex='-1'>Get This</h1>
+      </section>
+      {children}
+    </article>
+  );
 }
 
 GetThisPageTemplate.propTypes = {
@@ -60,7 +55,7 @@ class GetThisPage extends React.Component {
     const { record } = this.props;
     const { barcode, recordUid } = this.props.match.params;
 
-    if (record && record.fields && record.fields.length === 0 && record.names.length === 0) {
+    if (record?.fields?.length === 0 && record?.names?.length === 0) {
       return (
         <GetThisPageTemplate>
           <div className='alert'>

--- a/src/modules/lists/components/GoToList/index.js
+++ b/src/modules/lists/components/GoToList/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import { Anchor } from '../../../reusable';
 import PropTypes from 'prop-types';
-import { useLocation } from 'react-router-dom';
 
 function GoToList ({ list, datastore }) {
   const location = useLocation();

--- a/src/modules/lists/components/GoToList/index.js
+++ b/src/modules/lists/components/GoToList/index.js
@@ -1,25 +1,26 @@
 import React from 'react';
 import { Anchor } from '../../../reusable';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
-function GoToList (props) {
-  if (!props.list) return null;
+function GoToList ({ list, datastore }) {
+  const location = useLocation();
+
+  if (!list) return null;
 
   return (
     <section className='lists-link-container lists-link' aria-live='polite'>
       <div className='list-info'>
-        <p className='lists-content'>Go to <Anchor to={`/${props.datastore.slug}/list${props.location.search}`}>My Temporary {props.datastore.name} List</Anchor> to email, text, and export citations.</p>
+        <p className='lists-content'>Go to <Anchor to={`/${datastore.slug}/list${location.search}`}>My Temporary {datastore.name} List</Anchor> to email, text, and export citations.</p>
       </div>
-      <p className='lists-count-tag'><span className='strong'>{props.list?.length || 0}</span> in list</p>
+      <p className='lists-count-tag'><span className='strong'>{list.length || 0}</span> in list</p>
     </section>
   );
 }
 
 GoToList.propTypes = {
-  location: PropTypes.object,
   list: PropTypes.array,
   datastore: PropTypes.object
 };
 
-export default withRouter(GoToList);
+export default GoToList;

--- a/src/modules/records/components/Pagination/container.js
+++ b/src/modules/records/components/Pagination/container.js
@@ -1,117 +1,71 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
-import { Pagination } from '../../../reusable';
+import { useHistory } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { stringifySearchQueryForURL } from '../../../pride';
-import PropTypes from 'prop-types';
+import { Pagination } from '../../../reusable';
 
-class PaginationContainer extends React.Component {
-  /*
+const PaginationContainer = () => {
+  const history = useHistory();
+  const {
+    activeDatastoreUid,
+    filters,
+    institution,
     page,
-    total,
-    watchPageChange,
-    toNextPage,
-    toPreviousPage
-  */
+    records,
+    search,
+    sort,
+    total
+  } = useSelector((state) => {
+    return {
+      activeDatastoreUid: state.datastores.active,
+      filters: state.filters.active[state.datastores.active],
+      institution: state.institution,
+      page: state.search.data[state.datastores.active].page,
+      records: state.records.records[state.datastores.active],
+      search: state.search,
+      sort: state.search.sort[state.datastores.active],
+      total: state.search.data[state.datastores.active].totalPages
+    };
+  });
 
-  watchPageChange = (page) => {
-    const { history } = this.props;
-    history.push(this.createSearchQuery({ page }));
-  };
-
-  createSearchQuery = ({ page }) => {
-    const {
-      search,
-      filters,
-      activeDatastoreUid,
-      history,
-      institution,
-      sort
-    } = this.props;
-    const query = search.query;
-    const library = activeDatastoreUid === 'mirlyn' ? institution.active : undefined;
+  const createSearchQuery = (page) => {
     const queryString = stringifySearchQueryForURL({
-      query,
       filter: filters,
+      library: activeDatastoreUid === 'mirlyn' ? institution.active : undefined,
       page,
-      library,
+      query: search.query,
       sort
     });
 
     return `${history.location.pathname}?${queryString}`;
   };
 
-  toPreviousPage = () => {
-    const { page } = this.props;
-
-    // If there is only one page or you're on the first page.
-    if (page === 1) {
-      return undefined;
-    }
-
-    return this.createSearchQuery({
-      page: page - 1
-    });
+  const toPreviousPage = () => {
+    return page === 1 ? undefined : createSearchQuery(page - 1);
   };
 
-  toNextPage = () => {
-    const { page, total } = this.props;
-
-    // If you're on the last page, do not render a next page link.
-    if (total === 0 || page === total) {
-      return undefined;
-    }
-
-    return this.createSearchQuery({
-      page: page + 1
-    });
+  const toNextPage = () => {
+    return total === 0 || page === total ? undefined : createSearchQuery(page + 1);
   };
 
-  render () {
-    const { records, page, total } = this.props;
+  const watchPageChange = (newPage) => {
+    history.push(createSearchQuery(newPage));
+  };
 
-    if (!records || (records && records.length === 0)) {
-      return null;
-    }
-
-    return (
-      <Pagination
-        ariaLabel='Pagination'
-        page={page}
-        total={total}
-        watchPageChange={this.watchPageChange}
-        toNextPage={this.toNextPage()}
-        toPreviousPage={this.toPreviousPage()}
-      />
-    );
+  if (!records || records.length === 0) {
+    return null;
   }
-}
 
-PaginationContainer.propTypes = {
-  history: PropTypes.object,
-  search: PropTypes.object,
-  filters: PropTypes.object,
-  activeDatastoreUid: PropTypes.string,
-  institution: PropTypes.object,
-  sort: PropTypes.string,
-  records: PropTypes.array,
-  page: PropTypes.number,
-  total: PropTypes.number
+  return (
+    <Pagination
+      ariaLabel='Pagination'
+      page={page}
+      total={total}
+      watchPageChange={watchPageChange}
+      toNextPage={toNextPage()}
+      toPreviousPage={toPreviousPage()}
+    />
+  );
 };
 
-function mapStateToProps (state) {
-  return {
-    page: state.search.data[state.datastores.active].page,
-    total: state.search.data[state.datastores.active].totalPages,
-    records: state.records.records[state.datastores.active],
-    search: state.search,
-    activeDatastoreUid: state.datastores.active,
-    filters: state.filters.active[state.datastores.active],
-    institution: state.institution,
-    sort: state.search.sort[state.datastores.active]
-  };
-}
-
-export default withRouter(
-  connect(mapStateToProps)(PaginationContainer)
-);
+export default PaginationContainer;


### PR DESCRIPTION
# Overview
`history` and `react-router-dom` have been out of date for a while. Updating them to their current versions are breaking changes. One of those breaking changes is `withRouter` being deprecated. This pull request updates some components to replace the need for `withRouter`.

## Anything else?
To align with [current React practices](https://react.dev/learn/your-first-component), these class components have been converted to functional components:
- `GetThisPageTemplate`

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Poke around the site to see if anything is broken.
