### PR TITLE
`history` and `react-router-update` - Part 4

### DIFF
--- a/src/modules/advanced/components/AdvancedSearchForm/index.js
+++ b/src/modules/advanced/components/AdvancedSearchForm/index.js
@@ -1,9 +1,7 @@
-/** @jsxImportSource @emotion/react */
-import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import React, { useState, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { Icon, Alert } from '../../../reusable';
-import { withRouter } from 'react-router-dom';
 import FieldInput from '../FieldInput';
 import FiltersContainer from '../FiltersContainer';
 import { stringifySearchQueryForURL } from '../../../pride';
@@ -12,53 +10,62 @@ import {
   removeFieldedSearch,
   setFieldedSearch
 } from '../../../advanced';
-import _ from 'underscore';
 import PropTypes from 'prop-types';
 
-class AdvancedSearchForm extends React.Component {
-  state = {
-    errors: []
-  };
+function AdvancedSearchForm (props) {
+  const history = useHistory();
+  const [errors, setErrors] = useState([]);
+  const dispatch = useDispatch();
 
-  changeFieldedSearch = ({
-    fieldedSearchIndex,
-    selectedFieldUid,
-    query,
-    booleanType
-  }) => {
-    return this.props.setFieldedSearch({
-      datastoreUid: this.props.datastore.uid,
+  const { datastore } = props;
+  const fields = useSelector((state) => {
+    return state.advanced[datastore.uid].fields;
+  });
+  const booleanTypes = useSelector((state) => {
+    return state.advanced.booleanTypes;
+  });
+  const fieldedSearches = useSelector((state) => {
+    return state.advanced[datastore.uid].fieldedSearches;
+  });
+  const institution = useSelector((state) => {
+    return state.institution;
+  });
+  const activeFilters = useSelector((state) => {
+    const currentFilters = state.advanced[datastore.uid].activeFilters || {};
+    Object.keys(currentFilters).forEach((filter) => {
+      if (!currentFilters[filter]) delete currentFilters[filter];
+    });
+    return currentFilters;
+  });
+
+  // Functions wrapped with useCallback to prevent unnecessary re-creation
+  const changeFieldedSearch = useCallback(({ fieldedSearchIndex, selectedFieldUid, query, booleanType }) => {
+    dispatch(setFieldedSearch({
+      datastoreUid: datastore.uid,
       fieldedSearchIndex,
       selectedFieldUid,
       query,
       booleanType
-    });
-  };
+    }));
+  }, [dispatch, datastore.uid]);
 
-  handleAddAnotherFieldedSearch = () => {
-    this.props.addFieldedSearch({
-      datastoreUid: this.props.datastore.uid,
-      field: this.props.fields[0].uid
-    });
-  };
-
-  handleRemoveFieldedSearch ({ removeIndex }) {
-    this.props.removeFieldedSearch({
-      datastoreUid: this.props.datastore.uid,
-      removeIndex
-    });
-  }
-
-  handleSubmit = (e) => {
+  const handleAddAnotherFieldedSearch = useCallback((e) => {
     e.preventDefault();
+    dispatch(addFieldedSearch({
+      datastoreUid: datastore.uid,
+      field: fields[0].uid
+    }));
+  }, [dispatch, datastore.uid, fields]);
 
-    const {
-      fieldedSearches,
-      booleanTypes,
-      institution,
-      datastore,
-      activeFilters
-    } = this.props;
+  const handleRemoveFieldedSearch = useCallback(({ removeIndex }) => {
+    dispatch(removeFieldedSearch({
+      datastoreUid: datastore.uid,
+      removeIndex
+    }));
+  }, [dispatch, datastore.uid]);
+
+  const handleSubmit = useCallback((e) => {
+    e.preventDefault();
 
     // Build the query
     // example: 'title:parrots AND author:charles'
@@ -87,7 +94,6 @@ class AdvancedSearchForm extends React.Component {
     // TODO: Build the filters
     // Submit search if query or filters are active
     if (query.length > 0 || hasActiveFilters) {
-      const { history } = this.props;
       let library;
 
       if (datastore.uid === 'mirlyn') {
@@ -108,135 +114,77 @@ class AdvancedSearchForm extends React.Component {
       const url = `/${datastore.slug}?${queryString}`;
       history.push(url);
     } else {
-      this.setState({
-        errors: [
-          'A search term or option is required to submit an advanced search.'
-        ]
-      });
+      setErrors([
+        'A search term or option is required to submit an advanced search.'
+      ]);
       window.scrollTo(0, 0);
     }
-  };
+  }, [history, institution, booleanTypes, fieldedSearches, activeFilters, datastore]);
 
-  renderErrors = () => {
-    const { errors } = this.state;
+  return (
+    <form className='y-spacing' onSubmit={handleSubmit}>
+      <h2 style={{ fontSize: '1.87rem' }}>{datastore.name} Search</h2>
+      {errors.map((error, i) => {
+        return (
+          <Alert type='error' key={i}>
+            <div
+              className='x-spacing'
+              style={{ fontSize: '1rem' }}
+            >
+              <Icon icon='error' size={20} />
+              <span>{error}</span>
+            </div>
+          </Alert>
+        );
+      })}
 
-    if (errors) {
-      return (
-        <>
-          {errors.map((error, i) => {
-            return (
-              <Alert type='error' key={i}>
-                <div
-                  className='x-spacing'
-                  style={{
-                    fontSize: '1rem'
-                  }}
-                >
-                  <Icon icon='error' size={20} />
-                  <span>{error}</span>
-                </div>
-              </Alert>
-            );
-          })}
-        </>
-      );
-    }
+      <h3 className='offscreen'>Fielded search options</h3>
 
-    return null;
-  };
-
-  render () {
-    const { datastore, fields, fieldedSearches } = this.props;
-
-    return (
-      <form className='y-spacing' onSubmit={this.handleSubmit}>
-        <h2 css={{ fontSize: '1.87rem' }}>{datastore.name} Search</h2>
-        {this.renderErrors()}
-
-        <h3 className='offscreen'>Fielded search options</h3>
-
-        {fieldedSearches.map((fs, i) => {
-          return (
-            <FieldInput
-              key={i}
-              fieldedSearchIndex={i}
-              fieldedSearch={fs}
-              fields={fields}
-              changeFieldedSearch={this.changeFieldedSearch}
-              handleRemoveFieldedSearch={() => {
-                return this.handleRemoveFieldedSearch({ removeIndex: i });
-              }}
-              activeDatastore={datastore}
-            />
-          );
-        })}
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-around'
-          }}
-        >
-          <button
-            className='btn btn--small btn--secondary'
-            onClick={this.handleAddAnotherFieldedSearch}
-          >
-            Add another field
-          </button>
-        </div>
-
+      {fieldedSearches.map((fs, i) => {
+        return (
+          <FieldInput
+            key={i}
+            fieldedSearchIndex={i}
+            fieldedSearch={fs}
+            fields={fields}
+            changeFieldedSearch={changeFieldedSearch}
+            handleRemoveFieldedSearch={() => {
+              return handleRemoveFieldedSearch({ removeIndex: i });
+            }}
+            activeDatastore={datastore}
+          />
+        );
+      })}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-around'
+        }}
+      >
         <button
-          className='btn btn--primary'
-          style={{ marginTop: '1rem' }}
-          type='submit'
+          className='btn btn--small btn--secondary'
+          onClick={handleAddAnotherFieldedSearch}
+          type='button'
         >
-          <Icon icon='search' size={24} /> Advanced Search
+          Add another field
         </button>
+      </div>
 
-        <FiltersContainer datastore={datastore} />
-      </form>
-    );
-  }
-}
+      <button
+        className='btn btn--primary'
+        style={{ marginTop: '1rem' }}
+        type='submit'
+      >
+        <Icon icon='search' size={24} /> Advanced Search
+      </button>
 
-function mapDispatchToProps (dispatch) {
-  return bindActionCreators(
-    {
-      addFieldedSearch,
-      removeFieldedSearch,
-      setFieldedSearch
-    },
-    dispatch
+      <FiltersContainer datastore={datastore} />
+    </form>
   );
 }
 
-function mapStateToProps (state, props) {
-  const { datastore } = props;
-
-  return {
-    booleanTypes: state.advanced.booleanTypes,
-    fieldedSearches: state.advanced[datastore.uid].fieldedSearches,
-    fields: state.advanced[datastore.uid].fields,
-    institution: state.institution,
-    activeFilters: _.omit(
-      state.advanced[datastore.uid].activeFilters,
-      _.isEmpty
-    )
-  };
-}
-
 AdvancedSearchForm.propTypes = {
-  setFieldedSearch: PropTypes.func,
-  addFieldedSearch: PropTypes.func,
-  removeFieldedSearch: PropTypes.func,
-  fieldedSearches: PropTypes.array,
-  booleanTypes: PropTypes.array,
-  institution: PropTypes.object,
-  datastore: PropTypes.object,
-  activeFilters: PropTypes.object,
-  history: PropTypes.object,
-  fields: PropTypes.array
+  datastore: PropTypes.object.isRequired
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(AdvancedSearchForm)
-);
+export default AdvancedSearchForm;

--- a/src/modules/affiliation/actions/index.js
+++ b/src/modules/affiliation/actions/index.js
@@ -5,6 +5,6 @@ export const setDefaultAffiliation = (payload) => {
   return { type: SET_DEFAULT_AFFILIATION, payload };
 };
 
-export const setActiveAffilitation = (payload) => {
+export const setActiveAffiliation = (payload) => {
   return { type: SET_ACTIVE_AFFILIATION, payload };
 };

--- a/src/modules/affiliation/index.js
+++ b/src/modules/affiliation/index.js
@@ -1,6 +1,6 @@
 import ChooseAffiliation from './components/choose-affiliation';
 import affiliationReducer from './reducer';
-import { setDefaultAffiliation, setActiveAffilitation } from './actions';
+import { setDefaultAffiliation, setActiveAffiliation } from './actions';
 
 export function affiliationCookieSetter (affiliation) {
   if (affiliation) {
@@ -12,5 +12,5 @@ export {
   ChooseAffiliation,
   affiliationReducer,
   setDefaultAffiliation,
-  setActiveAffilitation
+  setActiveAffiliation
 };

--- a/src/modules/getthis/components/GetThisFindIt/index.js
+++ b/src/modules/getthis/components/GetThisFindIt/index.js
@@ -1,62 +1,36 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import { ResourceAccess } from '../../../reusable';
 import getHoldingByBarcode from '../../getHoldingByBarcode';
 import { StyledGetThisResourceAccessContainer } from '../GetThisRecord';
-import PropTypes from 'prop-types';
 
-function GetThisFindItHolding ({ holding }) {
-  return (
-    <div>
-      <p style={{ marginTop: '0' }}>Use this information to find it:</p>
+const GetThisFindIt = () => {
+  const { barcode } = useParams();
+  const record = useSelector((state) => {
+    return state.records.record;
+  });
 
-      <StyledGetThisResourceAccessContainer>
-        <ResourceAccess
-          {...holding[0]}
-          renderAnchor={() => {
-            return null;
-          }}
-        />
-      </StyledGetThisResourceAccessContainer>
-    </div>
-  );
-}
+  if (!record.resourceAccess) return null;
 
-GetThisFindItHolding.propTypes = {
-  holding: PropTypes.array
-};
+  const holding = getHoldingByBarcode(record.resourceAccess, barcode);
 
-class GetThisFindIt extends React.Component {
-  render () {
-    const { record } = this.props;
-    const { barcode } = this.props.match.params;
+  if (holding) {
+    return (
+      <>
+        <p className='u-margin-top-none'>Use this information to find it:</p>
 
-    if (record.resourceAccess) {
-      const holding = getHoldingByBarcode(record.resourceAccess, barcode);
-
-      if (holding) {
-        return (
-          <GetThisFindItHolding
-            holding={holding}
+        <StyledGetThisResourceAccessContainer>
+          <ResourceAccess
+            {...holding[0]}
+            renderAnchor={() => {
+              return null;
+            }}
           />
-        );
-      }
-    }
-
-    return null;
+        </StyledGetThisResourceAccessContainer>
+      </>
+    );
   }
-}
-
-GetThisFindIt.propTypes = {
-  record: PropTypes.object,
-  match: PropTypes.object
 };
 
-function mapStateToProps (state) {
-  return {
-    record: state.records.record
-  };
-}
-
-export default withRouter(connect(mapStateToProps)(GetThisFindIt));
+export default GetThisFindIt;

--- a/src/modules/getthis/components/GetThisPage/index.js
+++ b/src/modules/getthis/components/GetThisPage/index.js
@@ -1,78 +1,53 @@
-import React from 'react';
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useParams, useLocation } from 'react-router-dom';
 import { requestRecord, requestGetThis } from '../../../pride';
 import { GetThisOptionList, GetThisRecord } from '../../../getthis';
 import { Alert, Breadcrumb, H1 } from '../../../reusable';
-import PropTypes from 'prop-types';
 
-class GetThisPage extends React.Component {
-  componentDidMount () {
-    const { recordUid, barcode } = this.props.match.params;
-    const { datastoreUid } = this.props;
+const GetThisPage = () => {
+  const { recordUid, barcode } = useParams();
+  const location = useLocation();
+  const record = useSelector((state) => {
+    return state.records.record;
+  });
+  const datastoreUid = useSelector((state) => {
+    return state.datastores.active;
+  });
 
-    requestRecord({
-      recordUid,
-      datastoreUid
-    });
+  useEffect(() => {
+    requestRecord({ recordUid, datastoreUid });
+    requestGetThis({ datastoreUid, recordUid, barcode });
+  }, [recordUid, datastoreUid, barcode]);
 
-    requestGetThis({
-      datastoreUid,
-      recordUid,
-      barcode
-    });
-  }
-
-  render () {
-    const { record } = this.props;
-    const { barcode, recordUid } = this.props.match.params;
-
-    return (
-      <article className='container container-narrow'>
-        <div className='u-margin-top-1'>
-          <Breadcrumb
-            items={[
-              { text: 'Catalog', to: `/catalog${document.location.search}` },
-              { text: 'Record', to: `/catalog/record/${recordUid}${document.location.search}` },
-              { text: 'Get This' }
-            ]}
-          />
-        </div>
-        <H1 className='heading-xlarge'>Get This</H1>
-        {(() => {
-          if (record?.fields?.length === 0 && record?.names?.length === 0) {
-            return (
-              <section className='container__rounded page'>
-                <Alert type='error'>
-                  <span className='strong'>Error:</span> Unable to find this record.
-                </Alert>
-              </section>
-            );
-          }
-
-          return (
-            <>
-              <GetThisRecord barcode={barcode} />
-              <GetThisOptionList record={record} />
-            </>
-          );
-        })()}
-      </article>
-    );
-  }
-}
-
-GetThisPage.propTypes = {
-  match: PropTypes.object,
-  datastoreUid: PropTypes.string,
-  record: PropTypes.object
+  return (
+    <article className='container container-narrow'>
+      <div className='u-margin-top-1'>
+        <Breadcrumb
+          items={[
+            { text: 'Catalog', to: `/catalog${location.search}` },
+            { text: 'Record', to: `/catalog/record/${recordUid}${location.search}` },
+            { text: 'Get This' }
+          ]}
+        />
+      </div>
+      <H1 className='heading-xlarge'>Get This</H1>
+      {record?.fields?.length === 0 && record?.names?.length === 0
+        ? (
+          <section className='container__rounded page'>
+            <Alert type='error'>
+              <span className='strong'>Error:</span> Unable to find this record.
+            </Alert>
+          </section>
+          )
+        : (
+          <>
+            <GetThisRecord barcode={barcode} />
+            <GetThisOptionList record={record} />
+          </>
+          )}
+    </article>
+  );
 };
 
-function mapStateToProps (state) {
-  return {
-    record: state.records.record,
-    datastoreUid: state.datastores.active
-  };
-}
-
-export default withRouter(connect(mapStateToProps)(GetThisPage));
+export default GetThisPage;

--- a/src/modules/pride/components/URLSearchQueryWrapper/index.js
+++ b/src/modules/pride/components/URLSearchQueryWrapper/index.js
@@ -24,7 +24,7 @@ import {
 } from '../../../pride';
 import { setActiveInstitution } from '../../../institution';
 import { setA11yMessage } from '../../../a11y';
-import { affiliationCookieSetter, setActiveAffilitation } from '../../../affiliation';
+import { affiliationCookieSetter, setActiveAffiliation } from '../../../affiliation';
 import PropTypes from 'prop-types';
 
 function handleURLState ({
@@ -38,7 +38,7 @@ function handleURLState ({
 }, props) {
   const urlState = getStateFromURL({ location });
 
-  props.setActiveAffilitation(urlState.affiliation);
+  props.setActiveAffiliation(urlState.affiliation);
   affiliationCookieSetter(urlState.affiliation);
 
   if (!datastoreUid) return null;
@@ -199,7 +199,7 @@ export default withRouter(
         setActiveInstitution,
         setA11yMessage,
         setParserMessage,
-        setActiveAffilitation
+        setActiveAffiliation
       },
       dispatch
     );

--- a/src/modules/pride/components/URLSearchQueryWrapper/index.js
+++ b/src/modules/pride/components/URLSearchQueryWrapper/index.js
@@ -106,15 +106,23 @@ const URLSearchQueryWrapper = ({ children }) => {
   const datastoreUid = useSelector((state) => {
     return state.datastores.active;
   });
-  const { query, page, activeFilters, isSearching, sort, institution } = useSelector((state) => {
-    return {
-      query: state.search.query,
-      page: state.search.page[datastoreUid],
-      activeFilters: state.filters.active[datastoreUid],
-      isSearching: state.search.searching,
-      sort: state.search.sort[datastoreUid],
-      institution: state.institution
-    };
+  const query = useSelector((state) => {
+    return state.search.query;
+  });
+  const page = useSelector((state) => {
+    return state.search.page[datastoreUid];
+  });
+  const activeFilters = useSelector((state) => {
+    return state.filters.active[datastoreUid];
+  });
+  const isSearching = useSelector((state) => {
+    return state.search.searching;
+  });
+  const sort = useSelector((state) => {
+    return state.search.sort[datastoreUid];
+  });
+  const institution = useSelector((state) => {
+    return state.institution;
   });
   useEffect(() => {
     const datastoreUid = getDatastoreUidBySlug(params.datastoreSlug);

--- a/src/modules/pride/components/URLSearchQueryWrapper/index.js
+++ b/src/modules/pride/components/URLSearchQueryWrapper/index.js
@@ -124,6 +124,7 @@ const URLSearchQueryWrapper = ({ children }) => {
   const institution = useSelector((state) => {
     return state.institution;
   });
+
   useEffect(() => {
     const datastoreUid = getDatastoreUidBySlug(params.datastoreSlug);
     switchPrideToDatastore(datastoreUid);

--- a/src/modules/pride/components/URLSearchQueryWrapper/index.js
+++ b/src/modules/pride/components/URLSearchQueryWrapper/index.js
@@ -1,6 +1,5 @@
 import { useEffect, memo } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { connect, useDispatch } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import config from '../../../../config';
 import {
@@ -35,10 +34,10 @@ function handleURLState ({
   sort,
   location,
   institution
-}, props) {
+}, dispatch) {
   const urlState = getStateFromURL({ location });
 
-  props.setActiveAffiliation(urlState.affiliation);
+  dispatch(setActiveAffiliation(urlState.affiliation));
   affiliationCookieSetter(urlState.affiliation);
 
   if (!datastoreUid) return null;
@@ -55,8 +54,8 @@ function handleURLState ({
   if (Object.values(updateRequired).some(Boolean)) {
     if (updateRequired.query) {
       const newQuery = urlState.query || '';
-      props.setSearchQuery(newQuery);
-      props.setSearchQueryInput(newQuery);
+      dispatch(setSearchQuery(newQuery));
+      dispatch(setSearchQueryInput(newQuery));
     }
 
     if (updateRequired.filters) {
@@ -64,43 +63,44 @@ function handleURLState ({
         datastoreUid,
         filters: urlState.filter || null
       };
-      urlState.filter ? props.setActiveFilters(actionProps) : props.clearActiveFilters(actionProps);
+      dispatch(urlState.filter ? setActiveFilters(actionProps) : clearActiveFilters(actionProps));
     }
 
     if (updateRequired.page) {
-      props.setPage({
+      dispatch(setPage({
         page: urlState.page ? parseInt(urlState.page, 10) : 1,
         datastoreUid
-      });
+      }));
     }
 
     if (updateRequired.sort) {
-      props.setSort({
+      dispatch(setSort({
         sort: urlState.sort || config.sorts[datastoreUid].default,
         datastoreUid
-      });
+      }));
     }
 
     if (updateRequired.institution) {
-      props.setActiveInstitution(urlState.library);
+      dispatch(setActiveInstitution(urlState.library));
     }
 
-    props.setA11yMessage('Search modified.');
-    props.setParserMessage(null);
+    dispatch(setA11yMessage('Search modified.'));
+    dispatch(setParserMessage(null));
     runSearch();
   }
 
   // If URL does not have a state, reset the filters and the query
   if (!Object.keys(urlState).length) {
-    props.resetFilters();
-    props.setSearchQuery('');
+    dispatch(resetFilters());
+    dispatch(setSearchQuery(''));
   }
 
   // Decide if the UI should be in a "Searching" state based on URL having query or filter
-  props.searching(Boolean(urlState.query || urlState.filter));
+  dispatch(searching(Boolean(urlState.query || urlState.filter)));
 }
 
 const URLSearchQueryWrapper = (props) => {
+  const dispatch = useDispatch();
   const {
     match,
     isSearching,
@@ -125,8 +125,8 @@ const URLSearchQueryWrapper = (props) => {
       page: page[datastoreUid],
       sort: sort[datastoreUid],
       institution
-    }, props);
-  }, [match.params.datastoreSlug, isSearching, query, location.pathname, activeFilters, location, page, sort, institution, props]);
+    }, dispatch);
+  }, [match.params.datastoreSlug, isSearching, query, location.pathname, activeFilters, location, page, sort, institution, dispatch]);
 
   return children;
 };
@@ -160,21 +160,19 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({
-    setSearchQuery,
-    setSearchQueryInput,
-    setActiveFilters,
-    clearActiveFilters,
-    resetFilters,
-    searching,
-    setPage,
-    setSort,
-    setActiveInstitution,
-    setA11yMessage,
-    setParserMessage,
-    setActiveAffiliation
-  }, dispatch);
+const mapDispatchToProps = {
+  setSearchQuery,
+  setSearchQueryInput,
+  setActiveFilters,
+  clearActiveFilters,
+  resetFilters,
+  searching,
+  setPage,
+  setSort,
+  setActiveInstitution,
+  setA11yMessage,
+  setParserMessage,
+  setActiveAffiliation
 };
 
 function getURLPath (props) {

--- a/src/modules/pride/components/URLSearchQueryWrapper/index.js
+++ b/src/modules/pride/components/URLSearchQueryWrapper/index.js
@@ -9,10 +9,8 @@ import {
   searching,
   setPage,
   setSort,
-  resetSort,
   setParserMessage
 } from '../../../search/actions';
-import { loadingRecords } from '../../../records';
 import {
   resetFilters,
   setActiveFilters,
@@ -24,7 +22,6 @@ import {
   switchPrideToDatastore,
   getDatastoreUidBySlug
 } from '../../../pride';
-import { changeActiveDatastore } from '../../../datastores';
 import { setActiveInstitution } from '../../../institution';
 import { setA11yMessage } from '../../../a11y';
 import { affiliationCookieSetter, setActiveAffilitation } from '../../../affiliation';
@@ -197,11 +194,8 @@ export default withRouter(
         clearActiveFilters,
         resetFilters,
         searching,
-        loadingRecords,
-        changeActiveDatastore,
         setPage,
         setSort,
-        resetSort,
         setActiveInstitution,
         setA11yMessage,
         setParserMessage,

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -1,11 +1,9 @@
-/** @jsxImportSource @emotion/react */
-import React from 'react';
-import { connect } from 'react-redux';
-import _ from 'underscore';
-import { withRouter } from 'react-router-dom';
-import PropTypes from 'prop-types';
+import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { useParams, useHistory } from 'react-router-dom';
+import { findWhere } from '../../../reusable/underscore';
 import { Anchor, Breadcrumb, H1 } from '../../../reusable';
-import { COLORS, SEARCH_COLORS } from '../../../reusable/umich-lib-core-temp';
+import ResourceAccess from '../../../resource-acccess';
 import { TrimString } from '../../../core';
 import { getField, getFieldValue } from '../../utilities';
 import {
@@ -27,71 +25,56 @@ import {
   GoToList
 } from '../../../lists';
 import { NoMatch } from '../../../pages';
-import ResourceAccess from '../../../resource-acccess';
-
 let prejudiceInstance = prejudice.createVariableStorageDriverInstance();
 
-function FullRecordBreadcrumbs ({ datastore }) {
-  return (
-    <Breadcrumb
-      items={[
-        {
-          text: `${datastore.name}`,
-          to: `/${datastore.slug}${document.location.search}`
-        },
-        { text: 'Record' }
-      ]}
-    />
-  );
-}
+const FullRecord = () => {
+  const [activeAction, setActiveAction] = useState('');
 
-FullRecordBreadcrumbs.propTypes = {
-  datastore: PropTypes.object
-};
+  const params = useParams();
+  const history = useHistory();
 
-class FullRecord extends React.Component {
-  state = {
-    activeAction: ''
-  };
+  const record = useSelector((state) => {
+    return state.records.record;
+  });
+  const datastores = useSelector((state) => {
+    return state.datastores;
+  });
+  const list = useSelector((state) => {
+    return state.lists[datastores.active];
+  });
 
-  setActiveAction = (activeAction) => {
-    this.setState({ activeAction });
-  };
+  const recordUid = params.recordUid;
+  const datastoreUid = datastores.active;
+  const datastore = findWhere(datastores.datastores, {
+    uid: datastoreUid
+  });
 
-  componentDidMount () {
-    const { recordUid } = this.props.match.params;
-    const { datastoreUid } = this.props;
-
+  useEffect(() => {
     requestRecord({ recordUid, datastoreUid });
     prejudiceInstance = prejudice.createVariableStorageDriverInstance();
     prejudiceInstance.clearRecords();
     prejudiceInstance.addRecord({ recordUid, datastoreUid });
-  }
+  }, [recordUid, datastoreUid]);
 
-  componentDidUpdate () {
-    const { record, datastoreUid, datastores, history, datastore } = this.props;
-    const { recordUid } = this.props.match.params;
-
-    // If the record isn't in state
-    if (record && record.uid !== recordUid) {
-      if (datastoreUid === 'mirlyn' && recordUid.length === 9) {
-        // treat as an aleph id
-        history.push(`/catalog/record/${record.uid}`);
-      } else if (datastoreUid === 'onlinejournals' && recordUid.length === 9) {
-        // treat as an aleph id
-        history.push(`/onlinejournals/record/${record.uid}`);
-      } else if (_.contains(record.alt_ids, recordUid)) {
-        history.push(`/${datastore.slug}/record/${record.uid}`);
-      } else {
-        requestRecord({ recordUid, datastoreUid });
-      }
-    }
-
+  useEffect(() => {
     if (record) {
-      const activeDatastore = _.findWhere(datastores.datastores, {
+      if (record.uid !== recordUid) {
+        if (datastoreUid === 'mirlyn' && recordUid.length === 9) {
+          // treat as an aleph id
+          history.push(`/catalog/record/${record.uid}`);
+        } else if (datastoreUid === 'onlinejournals' && recordUid.length === 9) {
+          // treat as an aleph id
+          history.push(`/onlinejournals/record/${record.uid}`);
+        } else if (record.alt_ids.includes(recordUid)) {
+          history.push(`/${datastore.slug}/record/${record.uid}`);
+        } else {
+          requestRecord({ recordUid, datastoreUid });
+        }
+      }
+
+      const activeDatastore = findWhere(datastores.datastores, {
         uid: datastores.active
       });
-      // Set page title
 
       setDocumentTitle([
         [].concat(record.names).join().slice(0, 120),
@@ -99,12 +82,101 @@ class FullRecord extends React.Component {
         activeDatastore.name
       ]);
     }
+  }, [record, recordUid, datastores, history, datastore.slug, datastoreUid]);
+
+  if (!record) {
+    return (
+      <div className='container container-narrow y-spacing'>
+        <Breadcrumb
+          items={[
+            {
+              text: `${datastore.name}`,
+              to: `/${datastore.slug}${document.location.search}`
+            },
+            { text: 'Record' }
+          ]}
+        />
+        <FullRecordPlaceholder />
+      </div>
+    );
   }
 
-  renderActions = () => {
-    const { datastore, record } = this.props;
+  if (record.status === 404) {
+    return <NoMatch />;
+  }
 
+  // Check if the record in state matches the record ID in the URL
+  // If they don't match, then the new record is still being fetched.
+  const recordUidValue = getFieldValue(getField(record.fields, 'id'))[0];
+  if (recordUidValue !== recordUid) {
     return (
+      <div className='container container-narrow'>
+        <GoToList list={list} datastore={datastore} />
+        <FullRecordPlaceholder />
+      </div>
+    );
+  }
+
+  const inDatastore = ['catalog', 'onlinejournals'].includes(datastore.slug);
+
+  return (
+    <div className='container container-narrow full-record-page-container y-spacing'>
+      <Breadcrumb
+        items={[
+          {
+            text: `${datastore.name}`,
+            to: `/${datastore.slug}${document.location.search}`
+          },
+          { text: 'Record' }
+        ]}
+      />
+      <GoToList list={list} datastore={datastore} />
+      <div className={`container__rounded full-record-container ${isInList(list, record.uid) ? 'record--highlight' : ''}`}>
+        <RecordFullFormats formats={record.formats} />
+        <div className='record-container'>
+          <div className='full-record-title-and-actions-container'>
+            <H1 className='full-record-title'>
+              {[].concat(record.names).map((title, index) => {
+                if (index > 0) {
+                  return (
+                    <span className='vernacular vernacular-record-title' key={index}>
+                      <TrimString string={title} expandable />
+                    </span>
+                  );
+                }
+                return (
+                  <TrimString string={title} expandable key={index} />
+                );
+              })}
+              <RecommendedResource record={record} />
+            </H1>
+            <AddToListButton item={record} />
+          </div>
+          <RecordDescription record={record} />
+          <Zotero record={record} />
+          <h2 className='full-record__record-info'>Record info:</h2>
+          <RecordMetadata record={record} />
+          {inDatastore &&
+            <p>The University of Michigan Library aims to describe library materials in a
+              way that respects the people and communities who create, use, and are
+              represented in our collections. Report harmful or offensive language in catalog
+              records, finding aids, or elsewhere in our collections anonymously through
+              our <Anchor href='https://docs.google.com/forms/d/e/1FAIpQLSfSJ7y-zqmbNQ6ssAhSmwB7vF-NyZR9nVwBICFI8dY5aP1-TA/viewform'>metadata feedback form</Anchor>.
+              More information at <Anchor href='https://www.lib.umich.edu/about-us/policies/remediation-harmful-language-library-metadata'>Remediation of Harmful Language.</Anchor>
+            </p>}
+        </div>
+        <section aria-labelledby='available-at'>
+          <div
+            className='record-container'
+            style={{ paddingBottom: '0.25rem' }}
+          >
+            <h2 className='full-record__record-info' id='available-at'>
+              Available at:
+            </h2>
+          </div>
+          <ResourceAccess record={record} />
+        </section>
+      </div>
       <div className='full-record__actions-container'>
         <h2 className='lists-actions-heading u-display-inline-block u-margin-right-1 u-margin-bottom-none'>
           Actions{' '}
@@ -113,164 +185,25 @@ class FullRecord extends React.Component {
           </span>
         </h2>
         <ActionsList
-          setActive={this.setActiveAction}
-          active={this.state.activeAction}
+          setActive={setActiveAction}
+          active={activeAction}
           prejudice={prejudiceInstance}
           datastore={datastore}
           record={record}
         />
       </div>
-    );
-  };
-
-  render () {
-    const { record, datastoreUid, list, datastore } = this.props;
-    const { recordUid } = this.props.match.params;
-
-    if (!record) {
-      return (
-        <div className='container container-narrow y-spacing'>
-          <FullRecordBreadcrumbs datastore={datastore} />
-          <FullRecordPlaceholder />
-        </div>
-      );
-    }
-
-    if (record.status === 404) {
-      return <NoMatch />;
-    }
-
-    // Check if the record in state matches the record ID in the URL
-    // If they don't match, then the new record is still being fetched.
-    const recordUidValue = getFieldValue(getField(record.fields, 'id'))[0];
-    if (recordUidValue !== recordUid) {
-      return (
-        <div className='container container-narrow'>
-          <GoToList list={list} datastore={datastore} />
-          <FullRecordPlaceholder />
-        </div>
-      );
-    }
-
-    return (
-      <div className='container container-narrow full-record-page-container y-spacing'>
-        <FullRecordBreadcrumbs datastore={datastore} />
-        <GoToList list={list} datastore={datastore} />
-        <div className={`container__rounded full-record-container ${isInList(list, record.uid) ? 'record--highlight' : ''}`}>
-          <RecordFullFormats formats={record.formats} />
-          <div className='record-container'>
-            <div className='full-record-title-and-actions-container'>
-              <H1 className='full-record-title'>
-                {[].concat(record.names).map((title, index) => {
-                  if (index > 0) {
-                    return (
-                      <span className='vernacular vernacular-record-title' key={index}>
-                        <TrimString string={title} expandable />
-                      </span>
-                    );
-                  }
-                  return (
-                    <TrimString string={title} expandable key={index} />
-                  );
-                })}
-                <RecommendedResource record={record} />
-              </H1>
-              <AddToListButton item={record} />
-            </div>
-            <RecordDescription record={record} />
-            <Zotero record={record} />
-            <h2 className='full-record__record-info'>Record info:</h2>
-            <RecordMetadata record={record} />
-            <HarmfulLanguage datastore={datastore.slug} />
-          </div>
-
-          <section aria-labelledby='available-at'>
-            <div
-              className='record-container'
-              css={{ paddingBottom: '0.25rem' }}
-            >
-              <h2 className='full-record__record-info' id='available-at'>
-                Available at:
-              </h2>
-            </div>
-
-            <div
-              css={{
-                borderBottom: `solid 1px ${COLORS.neutral[100]}`
-              }}
-            >
-              <ResourceAccess record={record} />
-            </div>
-          </section>
-        </div>
-        {this.renderActions()}
-        <LastIndexed datastore={datastore.slug} record={record} />
-        {datastoreUid === 'mirlyn' && <ViewMARC record={record} />}
-      </div>
-    );
-  }
-}
-
-FullRecord.propTypes = {
-  record: PropTypes.object,
-  recordUid: PropTypes.string,
-  datastores: PropTypes.object,
-  datastore: PropTypes.object,
-  datastoreUid: PropTypes.string,
-  history: PropTypes.object,
-  list: PropTypes.array,
-  match: PropTypes.object
-};
-
-function HarmfulLanguage ({ datastore }) {
-  // Check if in correct datastore
-  if (!['catalog', 'onlinejournals'].includes(datastore)) return (null);
-  return (
-    <p>The University of Michigan Library aims to describe library materials in a
-      way that respects the people and communities who create, use, and are
-      represented in our collections. Report harmful or offensive language in catalog
-      records, finding aids, or elsewhere in our collections anonymously through
-      our <Anchor href='https://docs.google.com/forms/d/e/1FAIpQLSfSJ7y-zqmbNQ6ssAhSmwB7vF-NyZR9nVwBICFI8dY5aP1-TA/viewform'>metadata feedback form</Anchor>.
-      More information at <Anchor href='https://www.lib.umich.edu/about-us/policies/remediation-harmful-language-library-metadata'>Remediation of Harmful Language.</Anchor>
-    </p>
+      {inDatastore && (() => {
+        const indexingDate = findWhere(record.fields, { uid: 'indexing_date' });
+        if (!indexingDate) return null;
+        return (
+          <p style={{ color: 'var(--search-color-grey-600)', marginTop: 0, order: 3 }}>
+            <span style={{ fontWeight: 600 }}>{indexingDate.name}:</span> {indexingDate.value}
+          </p>
+        );
+      })()}
+      {datastoreUid === 'mirlyn' && <ViewMARC record={record} />}
+    </div>
   );
-}
-
-HarmfulLanguage.propTypes = {
-  datastore: PropTypes.string
 };
 
-function LastIndexed ({ datastore, record }) {
-  if (!['catalog', 'onlinejournals'].includes(datastore)) return (null);
-  const indexingDate = record
-    .fields
-    .filter((field) => {
-      return field.uid === 'indexing_date';
-    })[0];
-  if (!indexingDate) return null;
-  return (
-    <p style={{ color: SEARCH_COLORS.grey[500], marginTop: 0, order: 3 }}>
-      <span style={{ fontWeight: 600 }}>{indexingDate.name}:</span> {indexingDate.value}
-    </p>
-  );
-}
-
-LastIndexed.propTypes = {
-  datastore: PropTypes.string,
-  record: PropTypes.object
-};
-
-function mapStateToProps (state) {
-  return {
-    datastore: _.findWhere(state.datastores.datastores, {
-      uid: state.datastores.active
-    }),
-    record: state.records.record,
-    datastoreUid: state.datastores.active,
-    datastores: state.datastores,
-    institution: state.institution,
-    list: state.lists[state.datastores.active]
-  };
-}
-
-export default withRouter(connect(mapStateToProps)(FullRecord));
+export default FullRecord;

--- a/src/modules/records/components/Sorts/index.js
+++ b/src/modules/records/components/Sorts/index.js
@@ -5,11 +5,11 @@ import config from '../../../../config';
 import { stringifySearchQueryForURL } from '../../../pride';
 import PropTypes from 'prop-types';
 
-const Sorts = ({ activeFilters, datastoreUid, history, institution, search }) => {
+const Sorts = ({ activeFilters, activeDatastore, history, institution, search }) => {
   const { datastoreSlug } = useParams();
-  const sorts = (config.sorts[datastoreUid]?.sorts || [])
+  const sorts = (config.sorts[activeDatastore]?.sorts || [])
     .map((uid) => {
-      return findWhere(search.data[datastoreUid].sorts, { uid });
+      return findWhere(search.data[activeDatastore].sorts, { uid });
     }).filter((sort) => {
       return sort !== undefined;
     });
@@ -23,7 +23,7 @@ const Sorts = ({ activeFilters, datastoreUid, history, institution, search }) =>
     const queryString = stringifySearchQueryForURL({
       query: search.query,
       filter: activeFilters,
-      library: datastoreUid === 'mirlyn' ? institution.active : undefined,
+      library: activeDatastore === 'mirlyn' ? institution.active : undefined,
       sort: event.target.value
     });
 
@@ -40,7 +40,7 @@ const Sorts = ({ activeFilters, datastoreUid, history, institution, search }) =>
       <select
         id='sort-by'
         className='dropdown sorts-select'
-        value={search.sort[datastoreUid] || sorts[0].uid}
+        value={search.sort[activeDatastore] || sorts[0].uid}
         onChange={handleOnChange}
         autoComplete='off'
       >
@@ -58,7 +58,7 @@ const Sorts = ({ activeFilters, datastoreUid, history, institution, search }) =>
 
 Sorts.propTypes = {
   activeFilters: PropTypes.object,
-  datastoreUid: PropTypes.string,
+  activeDatastore: PropTypes.string,
   history: PropTypes.object,
   institution: PropTypes.object,
   search: PropTypes.object

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -7,10 +7,12 @@ import { Anchor, Icon } from '../../../reusable';
 import qs from 'qs';
 import SearchByOptions from '../SearchByOptions';
 import SearchTip from '../SearchTip';
-import PropTypes from 'prop-types';
-import { withRouter } from 'react-router';
+import { useHistory, useParams, useLocation } from 'react-router-dom';
 
-function SearchBox ({ history, match, location }) {
+function SearchBox () {
+  const history = useHistory();
+  const params = useParams();
+  const location = useLocation();
   const { query } = useSelector((state) => {
     return state.search;
   });
@@ -95,7 +97,7 @@ function SearchBox ({ history, match, location }) {
     // Set new URL
     const newURL = qs.stringify({
       // Preserve existing URL's tate
-      ...qs.parse(document.location.search.substring(1), { allowDots: true }),
+      ...qs.parse(location.search?.substring(1), { allowDots: true }),
       // If new search, return the first page
       page: undefined,
       // Add new query
@@ -111,7 +113,7 @@ function SearchBox ({ history, match, location }) {
     if (browseOption) {
       let href = 'https://browse.workshop.search.lib.umich.edu';
       if (window.location.hostname === 'search.lib.umich.edu') {
-        href = `/${match.params.datastoreSlug}/browse`;
+        href = `/${params.datastoreSlug}/browse`;
       }
       if (window.location.hostname === 'localhost') {
         href = 'http://localhost:4567';
@@ -121,7 +123,7 @@ function SearchBox ({ history, match, location }) {
       // Do not submit if query remains unchanged
       if (query === newQuery) return;
       // Submit new search
-      history.push(`/${match.params.datastoreSlug}?${newURL}`);
+      history.push(`/${params.datastoreSlug}?${newURL}`);
     }
   }
 
@@ -281,7 +283,7 @@ function SearchBox ({ history, match, location }) {
           </button>
           {isAdvanced && (
             <Anchor
-              to={`/${match.params.datastoreSlug}/advanced${location.search}`}
+              to={`/${params.datastoreSlug}/advanced${location.search}`}
               css={{
                 alignSelf: 'center',
                 fontWeight: '600',
@@ -306,10 +308,4 @@ function SearchBox ({ history, match, location }) {
   );
 }
 
-SearchBox.propTypes = {
-  history: PropTypes.object,
-  match: PropTypes.object,
-  location: PropTypes.object
-};
-
-export default withRouter(SearchBox);
+export default SearchBox;


### PR DESCRIPTION
# Overview
This pull request is a continuation of removing `withRouter` in order to update `history` and `react-router-dom`. These components have been rewritten to remove the need for `withRouter`:
- `AdvancedSearchForm`
- `FullRecord`
- `RecordListContainer`
- `SearchBox`
- `GetThisPage`
- `GetThisFindIt`
- `URLSearchQueryWrapper`

## Anything else?
To align with [current React practices](https://react.dev/learn/your-first-component), these class components have been converted to functional components:
- `AdvancedSearchForm`
- `FullRecord`
- `GetThisFindIt`
- `GetThisPage`
- `URLSearchQueryWrapper`

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Poke around the site and see if anything is broken.
