### PR TITLE
[LIBSEARCH-947] Button in Actions section does not activate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8649,9 +8649,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -8659,7 +8659,7 @@
         "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -8688,15 +8688,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -17272,9 +17263,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",

--- a/src/modules/filters/components/Filters/index.js
+++ b/src/modules/filters/components/Filters/index.js
@@ -282,17 +282,14 @@ function FilterGroupMultiselect ({ filters, group, uid, uuid, activeFilters }) {
         <span>{group.metadata.name}</span>
         <span
           css={{
-            color: 'var(--ds-color-neutral-300)'
+            color: 'var(--ds-color-neutral-300)',
+            'details:not([open]) > summary > & > svg:first-of-type, details[open] > summary > & > svg:last-of-type': {
+              display: 'none!important'
+            }
           }}
         >
-          <Icon
-            size={24}
-            d='M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z'
-          />
-          <Icon
-            size={24}
-            d='M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z'
-          />
+          <Icon size={24} icon='expand_less' />
+          <Icon size={24} icon='expand_more' />
         </span>
       </summary>
       <FilterGroupFilters

--- a/src/modules/lists/components/List/index.js
+++ b/src/modules/lists/components/List/index.js
@@ -54,7 +54,7 @@ function List (props) {
             <section className='lists-section'>
               <h2 className='lists-actions-heading u-display-inline-block u-margin-right-1 u-margin-bottom-none'>Actions</h2>
               <span className='text-small'>Select what to do with this list.</span>
-              <ActionsList {...props} setActive={setActive} active={active} prejudice={prejudice.instance} />
+              <ActionsList {...props} setActive={setActive} active={active} prejudice={prejudice.instance} datastore={activeDatastore} />
             </section>
             {tempList.map((record, index) => {
               return (


### PR DESCRIPTION
# Overview
Exporting a citation through a temporary list was not working due to `datastore` not being defined in `props`. `activeDatastore` provided the same results in the props, but was not called anywhere. This pull request directly defines `datastore`, and now allows you to export citations in both temporary lists and full records. 

This pull request fixes [LIBSEARCH-947](https://mlit.atlassian.net/browse/LIBSEARCH-947).

## Anything else?
The dropdown lists for filters while viewing records showed both up and down arrows. This has been fixed.

`npm audit fix` was also ran due to a couple of new vulnerabilities that popped up.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Create a temporary list and try to export the citations.
  - View a full record and try to export the citation.
