### PR TITLE
Replacing JSONSchema and URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/dependency_updates_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dependency_updates_template.md
@@ -19,7 +19,6 @@ These dependencies have been updated to their latest versions:
 - `react-router-dom`
 - `react-scripts`
 - `underscore`
-- `url`
 
 ## Workflows
 These actions have been updated to their latest versions:

--- a/.github/PULL_REQUEST_TEMPLATE/dependency_updates_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dependency_updates_template.md
@@ -9,7 +9,6 @@ These dependencies have been updated to their latest versions:
 - `core-js`
 - `eslint`
 - `eslint-plugin-react`
-- `jsonschema`
 - `prejudice`
 - `pride`
 - `prop-types`

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@reduxjs/toolkit": "^2.2.3",
         "citeproc": "^2.4.63",
         "core-js": "^3.37.0",
-        "jsonschema": "^1.4.1",
         "prejudice": "git+https://github.com/mlibrary/prejudice.git",
         "pride": "git+https://github.com/mlibrary/pride.git",
         "prop-types": "^15.8.1",
@@ -13293,14 +13292,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jsx-ast-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.1",
         "globals": "^15.1.0",
-        "react-scripts": "^5.0.1",
-        "url": "^0.11.3"
+        "react-scripts": "^5.0.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -18443,22 +18442,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/url": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
-      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^1.4.1",
-        "qs": "^6.11.2"
-      }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
     },
     "node_modules/use-sync-external-store": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
     "globals": "^15.1.0",
-    "react-scripts": "^5.0.1",
-    "url": "^0.11.3"
+    "react-scripts": "^5.0.1"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@reduxjs/toolkit": "^2.2.3",
     "citeproc": "^2.4.63",
     "core-js": "^3.37.0",
-    "jsonschema": "^1.4.1",
     "prejudice": "git+https://github.com/mlibrary/prejudice.git",
     "pride": "git+https://github.com/mlibrary/pride.git",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
# Overview
[`jsonschema`](https://www.npmjs.com/package/jsonschema) was only ever used once in `src/modules/pride/utils.js`. The code has been replaced with vanilla JavaScript and has been uninstalled.

`url` was also never used in the repository and has been uninstalled.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Look around the site to see if anything is broken.
