### PR TITLE
Eslint standard rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/dependency_updates_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dependency_updates_template.md
@@ -7,6 +7,8 @@ These dependencies have been updated to their latest versions:
 - `@reduxjs/toolkit`
 - `citeproc`
 - `eslint`
+- `eslint-plugin-import`
+- `eslint-plugin-n`
 - `eslint-plugin-react`
 - `prejudice`
 - `pride`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,33 +1,279 @@
-import globals from "globals";
-import pluginJs from "@eslint/js";
-import pluginReactConfig from "eslint-plugin-react/configs/recommended.js";
+import globals from 'globals';
+import * as pluginImport from 'eslint-plugin-import';
+import pluginN from 'eslint-plugin-n';
+import pluginJs from '@eslint/js';
+import pluginReactConfig from 'eslint-plugin-react/configs/recommended.js';
 
 export default [
   {
     settings: {
       react: {
-        version: "detect"
+        version: 'detect'
       }
     }
   },
   {
     languageOptions: {
+      ecmaVersion: 2022,
       globals: {
         ...globals.browser,
-        ...globals.node
+        ...globals.es2021,
+        ...globals.node,
+        document: 'readonly',
+        navigator: 'readonly',
+        window: 'readonly'
+      },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
       }
     }
   },
   {
+    plugins: {
+      import: pluginImport,
+      n: pluginN
+    }
+  },
+  {
     rules: {
-      "arrow-body-style": ["error", "always"], // Requires {} in arrow function body
-      "arrow-parens": ["error", "always"], // Requires () around arrow function arguments
-      "brace-style": ["error", "1tbs"], // Requires one true brace style
-      "no-empty-function": "error", // Require an empty function to at least have a comment explaining why
-      "no-var": "error", // Discourages using `var` and recommends using `let` or `const` instead
-      "semi": ["error", "always"] // Requires a semicolon wherever necessary
+      'accessor-pairs': ['error', { setWithoutGet: true, enforceForClassMembers: true }],
+      'array-bracket-spacing': ['error', 'never'],
+      'array-callback-return': ['error', {
+        allowImplicit: false,
+        checkForEach: false
+      }],
+      'arrow-spacing': ['error', { before: true, after: true }],
+      'block-spacing': ['error', 'always'],
+      camelcase: ['error', {
+        allow: ['^UNSAFE_'],
+        properties: 'never',
+        ignoreGlobals: true
+      }],
+      'comma-dangle': ['error', {
+        arrays: 'never',
+        objects: 'never',
+        imports: 'never',
+        exports: 'never',
+        functions: 'never'
+      }],
+      'comma-spacing': ['error', { before: false, after: true }],
+      'comma-style': ['error', 'last'],
+      'computed-property-spacing': ['error', 'never', { enforceForClassMembers: true }],
+      'constructor-super': 'error',
+      curly: ['error', 'multi-line'],
+      'default-case-last': 'error',
+      'dot-location': ['error', 'property'],
+      'dot-notation': ['error', { allowKeywords: true }],
+      'eol-last': 'error',
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
+      'func-call-spacing': ['error', 'never'],
+      'generator-star-spacing': ['error', { before: true, after: true }],
+      indent: ['error', 2, {
+        SwitchCase: 1,
+        VariableDeclarator: 1,
+        outerIIFEBody: 1,
+        MemberExpression: 1,
+        FunctionDeclaration: { parameters: 1, body: 1 },
+        FunctionExpression: { parameters: 1, body: 1 },
+        CallExpression: { arguments: 1 },
+        ArrayExpression: 1,
+        ObjectExpression: 1,
+        ImportDeclaration: 1,
+        flatTernaryExpressions: false,
+        ignoreComments: false,
+        ignoredNodes: [
+          'TemplateLiteral *',
+          'JSXElement',
+          'JSXElement > *',
+          'JSXAttribute',
+          'JSXIdentifier',
+          'JSXNamespacedName',
+          'JSXMemberExpression',
+          'JSXSpreadAttribute',
+          'JSXExpressionContainer',
+          'JSXOpeningElement',
+          'JSXClosingElement',
+          'JSXFragment',
+          'JSXOpeningFragment',
+          'JSXClosingFragment',
+          'JSXText',
+          'JSXEmptyExpression',
+          'JSXSpreadChild'
+        ],
+        offsetTernaryExpressions: true
+      }],
+      'key-spacing': ['error', { beforeColon: false, afterColon: true }],
+      'keyword-spacing': ['error', { before: true, after: true }],
+      'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+      'multiline-ternary': ['error', 'always-multiline'],
+      'new-cap': ['error', { newIsCap: true, capIsNew: false, properties: true }],
+      'new-parens': 'error',
+      'no-array-constructor': 'error',
+      'no-async-promise-executor': 'error',
+      'no-caller': 'error',
+      'no-case-declarations': 'error',
+      'no-class-assign': 'error',
+      'no-compare-neg-zero': 'error',
+      'no-cond-assign': 'error',
+      'no-const-assign': 'error',
+      'no-constant-condition': ['error', { checkLoops: false }],
+      'no-control-regex': 'error',
+      'no-debugger': 'error',
+      'no-delete-var': 'error',
+      'no-dupe-args': 'error',
+      'no-dupe-class-members': 'error',
+      'no-dupe-keys': 'error',
+      'no-duplicate-case': 'error',
+      'no-useless-backreference': 'error',
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'no-empty-character-class': 'error',
+      'no-empty-pattern': 'error',
+      'no-eval': 'error',
+      'no-ex-assign': 'error',
+      'no-extend-native': 'error',
+      'no-extra-bind': 'error',
+      'no-extra-boolean-cast': 'error',
+      'no-extra-parens': ['error', 'functions'],
+      'no-fallthrough': 'error',
+      'no-floating-decimal': 'error',
+      'no-func-assign': 'error',
+      'no-global-assign': 'error',
+      'no-implied-eval': 'error',
+      'no-import-assign': 'error',
+      'no-invalid-regexp': 'error',
+      'no-irregular-whitespace': 'error',
+      'no-iterator': 'error',
+      'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
+      'no-lone-blocks': 'error',
+      'no-loss-of-precision': 'error',
+      'no-misleading-character-class': 'error',
+      'no-prototype-builtins': 'error',
+      'no-useless-catch': 'error',
+      'no-mixed-operators': ['error', {
+        groups: [
+          ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+          ['&&', '||'],
+          ['in', 'instanceof']
+        ],
+        allowSamePrecedence: true
+      }],
+      'no-mixed-spaces-and-tabs': 'error',
+      'no-multi-spaces': 'error',
+      'no-multi-str': 'error',
+      'no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 0 }],
+      'no-new': 'error',
+      'no-new-func': 'error',
+      'no-new-object': 'error',
+      'no-new-symbol': 'error',
+      'no-new-wrappers': 'error',
+      'no-obj-calls': 'error',
+      'no-octal': 'error',
+      'no-octal-escape': 'error',
+      'no-proto': 'error',
+      'no-redeclare': ['error', { builtinGlobals: false }],
+      'no-regex-spaces': 'error',
+      'no-return-assign': ['error', 'except-parens'],
+      'no-self-assign': ['error', { props: true }],
+      'no-self-compare': 'error',
+      'no-sequences': 'error',
+      'no-shadow-restricted-names': 'error',
+      'no-sparse-arrays': 'error',
+      'no-tabs': 'error',
+      'no-template-curly-in-string': 'error',
+      'no-this-before-super': 'error',
+      'no-throw-literal': 'error',
+      'no-trailing-spaces': 'error',
+      'no-undef': 'error',
+      'no-undef-init': 'error',
+      'no-unexpected-multiline': 'error',
+      'no-unmodified-loop-condition': 'error',
+      'no-unneeded-ternary': ['error', { defaultAssignment: false }],
+      'no-unreachable': 'error',
+      'no-unreachable-loop': 'error',
+      'no-unsafe-finally': 'error',
+      'no-unsafe-negation': 'error',
+      'no-unused-expressions': ['error', {
+        allowShortCircuit: true,
+        allowTernary: true,
+        allowTaggedTemplates: true
+      }],
+      'no-unused-vars': ['error', {
+        args: 'none',
+        caughtErrors: 'none',
+        ignoreRestSiblings: true,
+        vars: 'all'
+      }],
+      'no-use-before-define': ['error', { functions: false, classes: false, variables: false }],
+      'no-useless-call': 'error',
+      'no-useless-computed-key': 'error',
+      'no-useless-constructor': 'error',
+      'no-useless-escape': 'error',
+      'no-useless-rename': 'error',
+      'no-useless-return': 'error',
+      'no-void': 'error',
+      'no-whitespace-before-property': 'error',
+      'no-with': 'error',
+      'object-curly-newline': ['error', { multiline: true, consistent: true }],
+      'object-curly-spacing': ['error', 'always'],
+      'object-property-newline': ['error', { allowMultiplePropertiesPerLine: true }],
+      'object-shorthand': ['warn', 'properties'],
+      'one-var': ['error', { initialized: 'never' }],
+      'operator-linebreak': ['error', 'after', { overrides: { '?': 'before', ':': 'before', '|>': 'before' } }],
+      'padded-blocks': ['error', { blocks: 'never', switches: 'never', classes: 'never' }],
+      'prefer-const': ['error', { destructuring: 'all' }],
+      'prefer-promise-reject-errors': 'error',
+      'prefer-regex-literals': ['error', { disallowRedundantWrapping: true }],
+      'quote-props': ['error', 'as-needed'],
+      quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }],
+      'rest-spread-spacing': ['error', 'never'],
+      'semi-spacing': ['error', { before: false, after: true }],
+      'space-before-blocks': ['error', 'always'],
+      'space-before-function-paren': ['error', 'always'],
+      'space-in-parens': ['error', 'never'],
+      'space-infix-ops': 'error',
+      'space-unary-ops': ['error', { words: true, nonwords: false }],
+      'spaced-comment': ['error', 'always', {
+        line: { markers: ['*package', '!', '/', ',', '='] },
+        block: { balanced: true, markers: ['*package', '!', ',', ':', '::', 'flow-include'], exceptions: ['*'] }
+      }],
+      'symbol-description': 'error',
+      'template-curly-spacing': ['error', 'never'],
+      'template-tag-spacing': ['error', 'never'],
+      'unicode-bom': ['error', 'never'],
+      'use-isnan': ['error', {
+        enforceForSwitchCase: true,
+        enforceForIndexOf: true
+      }],
+      'valid-typeof': ['error', { requireStringLiterals: true }],
+      'wrap-iife': ['error', 'any', { functionPrototypeMethods: true }],
+      'yield-star-spacing': ['error', 'both'],
+      yoda: ['error', 'never'],
+
+      'import/export': 'error',
+      'import/first': 'error',
+      'import/no-absolute-path': ['error', { esmodule: true, commonjs: true, amd: false }],
+      'import/no-duplicates': 'error',
+      'import/no-named-default': 'error',
+      'import/no-webpack-loader-syntax': 'error',
+
+      'n/handle-callback-err': ['error', '^(err|error)$'],
+      'n/no-callback-literal': 'error',
+      'n/no-deprecated-api': 'error',
+      'n/no-exports-assign': 'error',
+      'n/no-new-require': 'error',
+      'n/no-path-concat': 'error',
+      'n/process-exit-as-throw': 'error',
+
+      'arrow-body-style': ['error', 'always'], // Requires {} in arrow function body
+      'arrow-parens': ['error', 'always'], // Requires () around arrow function arguments
+      'brace-style': ['error', '1tbs'], // Requires one true brace style
+      'no-empty-function': 'error', // Require an empty function to at least have a comment explaining why
+      'no-var': 'error', // Discourages using `var` and recommends using `let` or `const` instead
+      semi: ['error', 'always'] // Requires a semicolon wherever necessary
     }
   },
   pluginJs.configs.recommended,
-  pluginReactConfig,
+  pluginReactConfig
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
       "devDependencies": {
         "@eslint/js": "^9.2.0",
         "eslint": "^8.57.0",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-n": "^17.5.1",
         "eslint-plugin-react": "^7.34.1",
         "globals": "^15.1.0",
         "react-scripts": "^5.0.1"
@@ -240,23 +242,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -3414,23 +3399,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/core/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@jest/core/node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -4212,14 +4180,14 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.3.tgz",
-      "integrity": "sha512-76dll9EnJXg4EVcI5YNxZA/9hSAmZsFqzMmNRHvIlzw2WS/twfcVX3ysYrWGJMClwEmChQFC4yRq74tn6fdzRA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.4.tgz",
+      "integrity": "sha512-EoIC9iC2V/DLRBVMXRHrO/oM3QBT7RuJNeBRx8Cpnz/NHINeZBEqgI8YOxAYUjLp+KYxGgc4Wd6KoAKsaUBGhg==",
       "dependencies": {
         "immer": "^10.0.3",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
-        "reselect": "^5.0.1"
+        "reselect": "^5.1.0"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18",
@@ -4317,23 +4285,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
-    },
-    "node_modules/@rollup/plugin-node-resolve/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/@rollup/plugin-replace": {
       "version": "2.4.2",
@@ -6077,23 +6028,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/babel-plugin-macros/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/babel-plugin-macros/node_modules/yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
@@ -6527,9 +6461,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001616",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001616.tgz",
-      "integrity": "sha512-RHVYKov7IcdNjVHJFNY/78RdG4oGVjbayxv8u5IO74Wv7Hlq4PnJE6mo/OjFijjVFNy5ijnCt6H3IIo4t+wfEw==",
+      "version": "1.0.30001617",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz",
+      "integrity": "sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==",
       "dev": true,
       "funding": [
         {
@@ -7836,9 +7770,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.758",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.758.tgz",
-      "integrity": "sha512-/o9x6TCdrYZBMdGeTifAP3wlF/gVT+TtWJe3BSmtNh92Mw81U9hrYwW9OAGUh+sEOX/yz5e34sksqRruZbjYrw==",
+      "version": "1.4.761",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.761.tgz",
+      "integrity": "sha512-PIbxpiJGx6Bb8dQaonNc6CGTRlVntdLg/2nMa1YhnrwYOORY9a3ZgGN0UQYE6lAcj/lkyduJN7BPt/JiY+jAQQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -8306,6 +8240,33 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.0.tgz",
+      "integrity": "sha512-dc6Y8tzEcSYZMHa+CMPLi/hyo1FzNeonbhJL7Ol0ccuKQkwopJcJBA9YL/xmMTLU1eKigXo9vj9nALElWYSowg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-compat-utils/node_modules/semver": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
+      "integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -8354,23 +8315,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/eslint-module-utils": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
@@ -8395,6 +8339,26 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.6.0.tgz",
+      "integrity": "sha512-I0AmeNgevgaTR7y2lrVCJmGYF0rjoznpDvqV/kIkZSZbZ8Rw3eu4cGlvBBULScfkSOCzqKbff5LR4CNrV7mZHA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.6.0",
+        "eslint-compat-utils": "^0.5.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
       }
     },
     "node_modules/eslint-plugin-flowtype": {
@@ -8521,6 +8485,67 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/eslint-plugin-n": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.5.1.tgz",
+      "integrity": "sha512-+E242KoY16xtwqqBRgSsDCrZ3K40jg3Np9fOgQyakcHaqymK3bnxYB1F1oe8Ksts8TDDViROFgraoLzbWhfHVw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "enhanced-resolve": "^5.15.0",
+        "eslint-plugin-es-x": "^7.5.0",
+        "get-tsconfig": "^4.7.0",
+        "globals": "^15.0.0",
+        "ignore": "^5.2.4",
+        "minimatch": "^9.0.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.23.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
+      "integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.34.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.1.tgz",
@@ -8575,6 +8600,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -9634,6 +9676,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.4.tgz",
+      "integrity": "sha512-ofbkKj+0pjXjhejr007J/fLf+sW+8H7K5GCm+msC8q3IpvgjobpyPqSRFemNyIMxklC0zeJpi7VDFna19FacvQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -9711,9 +9765,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.1.0.tgz",
-      "integrity": "sha512-926gJqg+4mkxwYKiFvoomM4J0kWESfk3qfTvRL2/oc/tK/eTDBbrfcKnSa2KtfdxB5onoL7D3A3qIHQFpd4+UA==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.2.0.tgz",
+      "integrity": "sha512-FQ5YwCHZM3nCmtb5FzEWwdUc9K5d3V/w9mzcz8iGD1gC/aOTHc6PouYu0kkKipNJqHAT7m51sqzQjEjIP+cK0A==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -11386,23 +11440,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-config/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/jest-config/node_modules/resolve.exports": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -11893,23 +11930,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "node_modules/jest-resolve/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/jest-runner": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
@@ -12063,23 +12083,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runner/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jest-runner/node_modules/resolve.exports": {
@@ -12258,23 +12261,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jest-runtime/node_modules/resolve.exports": {
@@ -13592,9 +13578,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.0.tgz",
-      "integrity": "sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.1.tgz",
+      "integrity": "sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==",
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -14110,9 +14096,9 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
-      "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.4.tgz",
+      "integrity": "sha512-nYo46tkNDCe4Ti+K4WP/ns2BjywqQMAeAz7r3lqtVkh8A0L9F86Ju2nLIrzFMUDSs1X0lHivbCiKG4eRUK2Z2Q==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -14787,23 +14773,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-import/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/postcss-initial": {
@@ -16108,23 +16077,6 @@
         }
       }
     },
-    "node_modules/react-scripts/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/react-scripts/node_modules/semver": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
@@ -16370,9 +16322,9 @@
       "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -16414,6 +16366,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resolve-url-loader": {
@@ -17405,9 +17366,9 @@
       }
     },
     "node_modules/sucrase/node_modules/glob": {
-      "version": "10.3.12",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
-      "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
+      "version": "10.3.13",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.13.tgz",
+      "integrity": "sha512-CQ9K7FRtaP//lXUKJVVYFxvozIz3HR4Brk+yB5VSkmWiHVILwd7NqQ2+UH6Ab5/NzCLib+j1REVV+FSZ+ZHOvg==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -17472,9 +17433,9 @@
       "dev": true
     },
     "node_modules/svgo": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.0.tgz",
-      "integrity": "sha512-y350OL6eAmhDbWcASdukXoG0MbpdfJQPHwEUAaTW1HBNSO2VErJ35fs7uNLSWjzFDhfua517RcouBzjZoO1JFg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
+      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
       "dev": true,
       "dependencies": {
         "@trysound/sax": "0.2.0",
@@ -17486,7 +17447,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "svgo": "bin/svgo.js"
+        "svgo": "bin/svgo"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -17608,23 +17569,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "devDependencies": {
     "@eslint/js": "^9.2.0",
     "eslint": "^8.57.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-n": "^17.5.1",
     "eslint-plugin-react": "^7.34.1",
     "globals": "^15.1.0",
     "react-scripts": "^5.0.1"
@@ -45,7 +47,8 @@
   "scripts": {
     "build": "react-scripts build",
     "build:dev": "CI=false REACT_APP_LOGIN_BASE_URL=http://localhost:3000 REACT_APP_SPECTRUM_BASE_URL=http://localhost:3000/spectrum npm run build && gtar -C build --transform s/./search/ -czf search.local.tar.gz .",
-    "lint": "npx eslint src",
+    "lint": "npx eslint src $*",
+    "lint:fix": "npm run lint -- --fix",
     "reinstall": "rm -rf node_modules && rm package-lock.json && npm install",
     "start": "REACT_APP_SPECTRUM_BASE_URL=${REACT_APP_SPECTRUM_BASE_URL:-https://search-staging.www.lib.umich.edu/spectrum} REACT_APP_LOGIN_BASE_URL=${REACT_APP_LOGIN_BASE_URL:-https://search-staging.www.lib.umich.edu} react-scripts start"
   },

--- a/src/modules/advanced/components/FiltersContainer/getFilters.js
+++ b/src/modules/advanced/components/FiltersContainer/getFilters.js
@@ -1,7 +1,7 @@
 import { findWhere } from '../../../reusable/underscore';
 import store from '../../../../store';
 
-const getCatalogNarrowSearchToOptions = (data, activeFilters) => { 
+const getCatalogNarrowSearchToOptions = (data, activeFilters) => {
   function getActiveFilter ({ uid, defaultFilter, filters }) {
     if (activeFilters && activeFilters[uid]) {
       return activeFilters[uid][0];

--- a/src/modules/filters/reducer/index.js
+++ b/src/modules/filters/reducer/index.js
@@ -55,10 +55,10 @@ const filtersReducer = function filterReducer (state = initialState, action) {
       active: {
         ...state.active,
         [datastoreUid]: Object.fromEntries(Object.entries(filters).map(
-            ([filterUid, filterValue]) => {
-              return [filterUid, [...filterValue]];
-            }
-          ))
+          ([filterUid, filterValue]) => {
+            return [filterUid, [...filterValue]];
+          }
+        ))
       }
     };
   }

--- a/src/modules/lists/prejudice.js
+++ b/src/modules/lists/prejudice.js
@@ -22,7 +22,7 @@ const addRecordsToList = () => {
     group[datastore].push(record);
     return group;
   }, {});
-  
+
   store.dispatch(addList(groupedRecords));
 };
 

--- a/src/modules/pride/setup.js
+++ b/src/modules/pride/setup.js
@@ -103,7 +103,7 @@ const setupObservers = (searchObj) => {
       const records = results.reduce((accumulator, result) => {
         result.renderFull((data) => {
           const { fields } = data;
-    
+
           accumulator.push({
             uid: getFieldValue(getField(fields, 'id'))[0],
             ...data,
@@ -111,7 +111,7 @@ const setupObservers = (searchObj) => {
             loadingHoldings: recordsHaveHoldings || undefined
           });
         });
-    
+
         return accumulator;
       }, []);
 
@@ -324,14 +324,14 @@ const setupSearches = () => {
     const foundDatastore = allDatastores.find((datastore) => {
       return datastore.get('uid') === uid;
     });
-  
+
     if (foundDatastore !== undefined) {
       const searchObj = foundDatastore.baseSearch();
       searchObj.set({ count: 10 });
       setupObservers(searchObj);
       memo.push(searchObj);
     }
-  
+
     return memo;
   }, []);
 
@@ -347,11 +347,11 @@ const setupSearches = () => {
     }).filter((foundSearchObj) => {
       return !!foundSearchObj;
     });
-  
+
     if (multiSearchInternalObjects.length) {
       memo.push(new MultiSearch(multiDatastoreConfig.uid, true, multiSearchInternalObjects));
     }
-  
+
     return memo;
   }, []);
 

--- a/src/modules/pride/utils.js
+++ b/src/modules/pride/utils.js
@@ -76,9 +76,9 @@ const isValidURLSearchQuery = ({ urlState }) => {
 
     for (const [prop, value] of Object.entries(filter)) {
       if (!/^([A-Za-z0-9_])+$/.test(prop)) return false;
-      const isStringOrArray = typeof value === 'string' || Array.isArray(value) && value.every((item) => {
+      const isStringOrArray = typeof value === 'string' || (Array.isArray(value) && value.every((item) => {
         return typeof item === 'string';
-      });
+      }));
       if (!isStringOrArray) return false;
     }
   }


### PR DESCRIPTION
# Overview
When setting up the new `eslint`, a lot of rules went away. This pull request reinstalls these two plugins and applies all of the original rules from [`eslint-config-standard`](https://github.com/standard/eslint-config-standard/blob/master/src/index.ts):
- `eslint-plugin-import`
- `eslint-plugin-n`

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Run `npm run lint` and `npm run lint:fix` to see if it works.
