### PR TITLE
TypeError: Cannot read properties of undefined (reading 'email')

### DIFF
--- a/src/modules/lists/components/ActionsList/index.js
+++ b/src/modules/lists/components/ActionsList/index.js
@@ -88,6 +88,7 @@ function ActionsList (props) {
             <AuthenticationRequired profile={profile}>
               <EmailAction
                 action={props.active}
+                emailAddress={profile?.email || ''}
                 {...props}
               />
             </AuthenticationRequired>
@@ -96,6 +97,7 @@ function ActionsList (props) {
             <AuthenticationRequired profile={profile}>
               <TextAction
                 action={props.active}
+                phoneNumber={profile?.text || ''}
                 {...props}
               />
             </AuthenticationRequired>

--- a/src/modules/lists/components/EmailAction/index.js
+++ b/src/modules/lists/components/EmailAction/index.js
@@ -2,12 +2,12 @@ import React, { useState } from 'react';
 import ActionStatusMessage from '../ActionStatusMessage';
 import PropTypes from 'prop-types';
 
-function EmailAction (props) {
-  const [email, setEmail] = useState(props.profile.email || '');
+function EmailAction ({ emailAddress, prejudice, datastore, setActive, action }) {
+  const [email, setEmail] = useState(emailAddress);
   const [status, setStatus] = useState(undefined);
 
   const setCloseStatus = () => {
-    props.setActive('');
+    setActive('');
     setStatus(undefined);
   };
 
@@ -17,13 +17,13 @@ function EmailAction (props) {
 
   return (
     <section className='lists-action'>
-      <ActionStatusMessage status={status} action={props.action} setCloseStatus={setCloseStatus} />
+      <ActionStatusMessage status={status} action={action} setCloseStatus={setCloseStatus} />
       {(!status || status.status_code !== 'action.response.success') &&
         <form
           className='lists-action-form'
           onSubmit={(event) => {
             event.preventDefault();
-            props.prejudice.act('email', props.datastore.uid, email, handleSubmitCallback);
+            prejudice.act('email', datastore.uid, email, handleSubmitCallback);
           }}
         >
           <div className='lists-action-field-container'>
@@ -52,7 +52,7 @@ function EmailAction (props) {
 }
 
 EmailAction.propTypes = {
-  profile: PropTypes.object,
+  emailAddress: PropTypes.string,
   prejudice: PropTypes.object,
   datastore: PropTypes.object,
   setActive: PropTypes.func,

--- a/src/modules/lists/components/TextAction/index.js
+++ b/src/modules/lists/components/TextAction/index.js
@@ -2,12 +2,12 @@ import React, { useState } from 'react';
 import ActionStatusMessage from '../ActionStatusMessage';
 import PropTypes from 'prop-types';
 
-function TextAction (props) {
-  const [text, setText] = useState(props.profile.text || '');
+function TextAction ({ phoneNumber, prejudice, datastore, setActive, action }) {
+  const [text, setText] = useState(phoneNumber);
   const [status, setStatus] = useState(undefined);
 
   const setCloseStatus = () => {
-    props.setActive('');
+    setActive('');
     setStatus(undefined);
   };
 
@@ -17,13 +17,13 @@ function TextAction (props) {
 
   return (
     <section className='lists-action'>
-      <ActionStatusMessage status={status} action={props.action} setCloseStatus={setCloseStatus} />
+      <ActionStatusMessage status={status} action={action} setCloseStatus={setCloseStatus} />
       {(!status || status.status_code !== 'action.response.success') &&
         <form
           className='lists-action-form'
           onSubmit={(event) => {
             event.preventDefault();
-            props.prejudice.act('text', props.datastore.uid, text, handleSubmitCallback);
+            prejudice.act('text', datastore.uid, text, handleSubmitCallback);
           }}
         >
           <div className='lists-action-field-container'>
@@ -55,7 +55,7 @@ function TextAction (props) {
 }
 
 TextAction.propTypes = {
-  profile: PropTypes.object,
+  phoneNumber: PropTypes.string,
   prejudice: PropTypes.object,
   datastore: PropTypes.object,
   setActive: PropTypes.func,


### PR DESCRIPTION
# Overview
When using an Email or Text action on a record, it would produce this error:
```
TypeError: Cannot read properties of undefined (reading 'email')
```
This pull request adds a check to see if `profile` exists, along with the `email` or `text` properties. If so, get the values. If not, default to an empty string.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
