### PR TITLE
[LIBSEARCH-987] Add a Class to <a> element in the "Resource Access" component

### DIFF
--- a/src/modules/resource-acccess/components/Holding/index.js
+++ b/src/modules/resource-acccess/components/Holding/index.js
@@ -49,7 +49,7 @@ export default function Holding ({ holding }) {
       {holding.map((cell, index) => {
         return (
           <td
-            className={cell.intent && `intent__${[cell.intent]}`}
+            className={(index === 0 && 'access-link-cell') || (cell.intent && `intent__${[cell.intent]}`)}
             key={index}
           >
             <Cell cell={cell} />


### PR DESCRIPTION
# Overview
To simplify Google Tag Manager triggers, the class `access-link-cell` has been added to the first column of every `Holding` row in `tbody`.

This pull request resolves [LIBSEARCH-987](https://mlit.atlassian.net/browse/LIBSEARCH-987).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check a record that has holdings. Inspect the element that has the link Get This, Available online, Go to item, Go to database, Go to online journal, Request access, etc. and see if its parent cell has the class `access-link-cell`.
