### PR TITLE
[LIBSEARCH-985] Update "remediation of harmful language" statement displayed on Catalog records

### DIFF
--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -160,16 +160,13 @@ const FullRecord = () => {
           <RecordMetadata record={record} />
           {inDatastore && (
             <p>
-              The University of Michigan Library aims to describe library materials in a
-              way that respects the people and communities who create, use, and are
-              represented in our collections. Report harmful or offensive language in catalog
-              records, finding aids, or elsewhere in our collections anonymously through
-              our
+              The University of Michigan Library aims to describe its collections in a way that respects the people and communities who create, use, and are represented in them. We encourage you to
               {' '}
-              <Anchor href='https://docs.google.com/forms/d/e/1FAIpQLSfSJ7y-zqmbNQ6ssAhSmwB7vF-NyZR9nVwBICFI8dY5aP1-TA/viewform'>metadata feedback form</Anchor>
-              . More information at
+              <Anchor href='https://docs.google.com/forms/d/e/1FAIpQLSfSJ7y-zqmbNQ6ssAhSmwB7vF-NyZR9nVwBICFI8dY5aP1-TA/viewform?utm_source=library-search'>contact us</Anchor>
               {' '}
-              <Anchor href='https://www.lib.umich.edu/about-us/policies/remediation-harmful-language-library-metadata'>Remediation of Harmful Language.</Anchor>
+              anonymously if you encounter harmful or problematic language in catalog records or finding aids. More information about our policies and practices is available at
+              {' '}
+              <Anchor href='https://www.lib.umich.edu/about-us/policies/remediation-harmful-language-library-metadata?utm_source=library-search'>Remediation of Harmful Language</Anchor>.
             </p>
           )}
         </div>


### PR DESCRIPTION
# Overview
The DEIA Catalog Working Group has updated the remediation of harmful language statement.

This pull request closes [LIBSEARCH-985](https://mlit.atlassian.net/browse/LIBSEARCH-985).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Compare a Catalog record on the production site vs. the new changes to see if the content has been updated.
