### PR TITLE
Move inline styles out of files.

### DIFF
--- a/src/modules/advanced/components/AdvancedSearchContainer/index.js
+++ b/src/modules/advanced/components/AdvancedSearchContainer/index.js
@@ -17,7 +17,7 @@ const AdvancedSearchContainer = () => {
   const activeDatastore = datastores[activeDatastoreIndex];
 
   return (
-    <div className='container container-narrow' style={{ marginTop: 'var(--search-spacing-m)' }}>
+    <div className='container container-narrow margin-top__m'>
       <Breadcrumb
         items={[
           { text: `${activeDatastore.name}`, to: `/${activeDatastore.slug}${document.location.search}` },

--- a/src/modules/advanced/components/AdvancedSearchForm/index.js
+++ b/src/modules/advanced/components/AdvancedSearchForm/index.js
@@ -1,3 +1,4 @@
+import './styles.css';
 import {
   addFieldedSearch,
   removeFieldedSearch,
@@ -113,14 +114,11 @@ const AdvancedSearchForm = ({ datastore }) => {
 
   return (
     <form className='y-spacing' onSubmit={handleSubmit}>
-      <h2 style={{ fontSize: '1.87rem' }}>{datastore.name} Search</h2>
+      <h2 className='h1'>{datastore.name} Search</h2>
       {errors.map((error, index) => {
         return (
           <Alert type='error' key={index}>
-            <div
-              className='x-spacing'
-              style={{ fontSize: '1rem' }}
-            >
+            <div className='x-spacing h4'>
               <Icon icon='error' size={20} />
               <span>{error}</span>
             </div>
@@ -145,20 +143,13 @@ const AdvancedSearchForm = ({ datastore }) => {
           />
         );
       })}
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-around'
-        }}
+      <button
+        className='btn btn--small btn--secondary add-another-field'
+        onClick={handleAddAnotherFieldedSearch}
+        type='button'
       >
-        <button
-          className='btn btn--small btn--secondary'
-          onClick={handleAddAnotherFieldedSearch}
-          type='button'
-        >
-          Add another field
-        </button>
-      </div>
+        Add another field
+      </button>
 
       <button
         className='btn btn--primary margin-top__m'

--- a/src/modules/advanced/components/AdvancedSearchForm/styles.css
+++ b/src/modules/advanced/components/AdvancedSearchForm/styles.css
@@ -1,0 +1,5 @@
+.add-another-field {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/src/modules/advanced/components/FiltersContainer/index.js
+++ b/src/modules/advanced/components/FiltersContainer/index.js
@@ -1,3 +1,4 @@
+import './styles.css';
 import { useDispatch, useSelector } from 'react-redux';
 import AdvancedFilter from '../AdvancedFilter';
 import getFilters from './getFilters';
@@ -51,36 +52,22 @@ const ActiveAdvancedFilters = (datastore) => {
 
   return (
     <section aria-label='active-filters'>
-      <div
-        style={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: '0.25em'
-        }}
+      <h2
+        id='active-filters'
+        className='u-margin-top-none margin-bottom__xs h4'
       >
-        <h2
-          id='active-filters'
-          className='u-margin-top-none margin-bottom__xs'
-          style={{ fontSize: '1rem' }}
-        >
-          Active filters
-        </h2>
+        Active filters
+        {' '}
         <span className='text-grey__light padding-right__xs'>
           ({items.length})
         </span>
-      </div>
+      </h2>
 
       <p className='font-small u-margin-top-none'>
         Unselect active filters through the options below.
       </p>
 
-      <ul
-        style={{
-          fontSize: '0.9rem',
-          marginLeft: '2.5rem',
-          marginTop: '0'
-        }}
-      >
+      <ul className='margin-top__none active-filter-list'>
         {items.map((item, index) => {
           return (
             <li key={index + item.group + item.value}>
@@ -201,8 +188,7 @@ const FiltersContainer = ({ datastore }) => {
         })}
       </div>
       <button
-        style={{ marginTop: '1rem' }}
-        className='btn btn--primary'
+        className='btn btn--primary margin-top__m'
         type='submit'
       >
         <Icon icon='search' size={24} /> Advanced Search

--- a/src/modules/advanced/components/FiltersContainer/styles.css
+++ b/src/modules/advanced/components/FiltersContainer/styles.css
@@ -1,0 +1,8 @@
+#active-filters > .text-grey__light {
+  font-weight: 400;
+}
+
+.active-filter-list {
+  font-size: 0.9rem;
+  margin-left: 2.5rem;
+}

--- a/src/modules/core/components/Footer/index.js
+++ b/src/modules/core/components/Footer/index.js
@@ -10,13 +10,11 @@ const Footer = () => {
           target='_blank'
           rel='noopener noreferrer'
           aria-label='Give feedback about this page - Opens in new window'
-          style={{ padding: '.15em' }}
         >
           Give feedback about this page
           <Icon
             icon='open_in_new'
-            size={22}
-            style={{ paddingLeft: '.25em' }}
+            className='margin-left__2xs'
           />
         </Anchor>
       </aside>

--- a/src/modules/datastores/components/FlintAlerts/index.js
+++ b/src/modules/datastores/components/FlintAlerts/index.js
@@ -22,14 +22,7 @@ const FlintAlerts = ({ datastore, profile }) => {
 
   return (
     <Alert type='warning'>
-      <div
-        style={{
-          alignItems: 'center',
-          display: 'flex',
-          gap: '1rem',
-          justifyContent: 'center'
-        }}
-      >
+      <div className='flex alert--flint'>
         <span>{messages[datastore]}</span>
         <button
           className='btn btn--small btn--secondary no-background'

--- a/src/modules/getthis/components/GetThisFindIt/index.js
+++ b/src/modules/getthis/components/GetThisFindIt/index.js
@@ -21,7 +21,6 @@ const Cell = ({ href, html, icon, text }) => {
         <Icon
           icon={icon}
           className='margin-right__2xs'
-          style={{ marginTop: '-2px' }}
         />
       )}
       {href && <Anchor href={href}>{text}</Anchor>}

--- a/src/modules/getthis/components/GetThisOption/index.js
+++ b/src/modules/getthis/components/GetThisOption/index.js
@@ -24,7 +24,7 @@ const GetThisOption = ({ option }) => {
                   <GetThisForm label={option.label} form={option.form} />
                 </>
               )
-            : option.label === 'Find it in the library' && <GetThisFindIt />}
+            : option.label === 'Get it off the shelves' && <GetThisFindIt />}
         </div>
 
         {option.description && (

--- a/src/modules/getthis/components/GetThisRecord/index.js
+++ b/src/modules/getthis/components/GetThisRecord/index.js
@@ -39,12 +39,7 @@ const GetThisRecord = ({ barcode }) => {
       </div>
 
       {holding && (
-        <div
-          className='get-this-resource-access-container'
-          style={{
-            borderBottom: 'solid 1px var(--ds-color-neutral-100)'
-          }}
-        >
+        <div className='get-this-resource-access-container record-holders-container'>
           <h3 className='visually-hidden'>Available at</h3>
           <ResourceAccess record={{
             resourceAccess: [].concat({

--- a/src/modules/lists/components/ActionsList/index.js
+++ b/src/modules/lists/components/ActionsList/index.js
@@ -77,9 +77,7 @@ const ActionsList = (props) => {
                     }}
                     aria-pressed={Boolean(isActive)}
                   >
-                    <span style={{ opacity: '0.75' }}>
-                      <Icon size={20} icon={action.icon} />
-                    </span>
+                    <Icon size={20} icon={action.icon} className={isActive ? null : 'text-grey'} />
                     {action.name}
                   </button>
                 </li>

--- a/src/modules/lists/components/CitationAction/index.js
+++ b/src/modules/lists/components/CitationAction/index.js
@@ -1,3 +1,4 @@
+import './styles.css';
 import React, { useEffect, useState } from 'react';
 import { Tab, TabPanel, Tabs } from '../../../reusable';
 import { cite } from '../../../citations';
@@ -107,12 +108,6 @@ const CitationAction = ({ datastore, list, record, setActive, setAlert, viewType
                     </label>
                     <div
                       id={`citation-text-${citationOption.id}`}
-                      style={{
-                        border: 'solid 1px var(--search-color-grey-400)',
-                        boxShadow: 'none',
-                        maxHeight: '40vh',
-                        overflowY: 'auto'
-                      }}
                       className='y-spacing copy-citation padding-y__xs padding-x__s container__rounded'
                       contentEditable
                       aria-describedby={`${citationOption.id}-disclaimer`}

--- a/src/modules/lists/components/CitationAction/styles.css
+++ b/src/modules/lists/components/CitationAction/styles.css
@@ -1,0 +1,6 @@
+.copy-citation {
+  border: solid 1px var(--search-color-grey-400);
+  box-shadow: none;
+  max-height: 40vh;
+  overflow-y: auto;
+}

--- a/src/modules/lists/components/EmailAction/index.js
+++ b/src/modules/lists/components/EmailAction/index.js
@@ -42,9 +42,8 @@ const EmailAction = ({ action, datastore, emailAddress, prejudice, setActive }) 
           <button
             className='btn btn--primary'
             type='submit'
-            style={{ whiteSpace: 'nowrap' }}
           >
-            Send email
+            Send&nbsp;email
           </button>
         </form>
       )}

--- a/src/modules/lists/components/List/index.js
+++ b/src/modules/lists/components/List/index.js
@@ -48,7 +48,7 @@ const List = (props) => {
           <p className='lists-count-tag'><span className='strong'>{listLength}</span> in list</p>
         </div>
       </div>
-      <p className='font-lede' style={{ marginTop: '0' }}>Items in this list are stored temporarily (within a single session).</p>
+      <p className='font-lede margin-top__none'>Items in this list are stored temporarily (within a single session).</p>
       {listLength
         ? (
             <>

--- a/src/modules/lists/components/TextAction/index.js
+++ b/src/modules/lists/components/TextAction/index.js
@@ -45,9 +45,8 @@ const TextAction = ({ action, datastore, phoneNumber, prejudice, setActive }) =>
           <button
             className='btn btn--primary'
             type='submit'
-            style={{ whiteSpace: 'nowrap' }}
           >
-            Send text
+            Send&nbsp;text
           </button>
         </form>
       )}

--- a/src/modules/pages/components/AboutLibrarySearch/index.js
+++ b/src/modules/pages/components/AboutLibrarySearch/index.js
@@ -26,7 +26,7 @@ const AboutLibrarySearch = () => {
           <li><em>Pride</em>, which handles searches</li>
           <li><em>Prejudice</em>, which handles integrations with the campus directory for authentication and other services</li>
         </ul>
-        <p><img src={schematicImage} alt='' style={{ height: 'auto', maxWidth: '100%' }} /></p>
+        <p><img src={schematicImage} alt='' /></p>
         <h2>Flexibility</h2>
         <p>Library Search is designed to separate the user experience from the particular system that provides or manages the data. This allowed us, in summer 2021, to switch library management systems and article discovery systems from Aleph and Summon to Alma and Primo with minimal need for changes to the user experience. This approach brings several other benefits, as well:</p>
         <ul>

--- a/src/modules/pages/components/TechnicalOverview/index.js
+++ b/src/modules/pages/components/TechnicalOverview/index.js
@@ -16,7 +16,7 @@ const TechnicalOverview = () => {
         <p>Library Search is built in three main layers to allow for flexibility in the front end and back end data repositories. A different front end application should not require rewriting the search queries, while conversely changes to one or more back-end search indexes or repositories would not require updates to the user interface. The middle layer acts as translator between the front and back ends.</p>
         <p>For more information about Library Search, please contact <Anchor href='mailto:library-search-feedback@umich.edu'>library-search-feedback@umich.edu</Anchor>.</p>
         <h2>High-Level Schematic</h2>
-        <p><img src={schematicImage} alt='' style={{ height: 'auto', maxWidth: '100%' }} /></p>
+        <p><img src={schematicImage} alt='' /></p>
         <h2>Front-End / User Interface</h2>
         <p>The user interface for Library Search, shown at the top of the above schematic, is a Single Page Application built with <Anchor href='https://reactjs.org/'>React</Anchor> (JavaScript library for building UIs) and developed in-house. It aims to meet the latest <Anchor href='https://www.w3.org/WAI/WCAG21/quickref/?versions=2.1'>WCAG AA Standards</Anchor> and is responsive. Its role is to display the search interface to the user, pass user search queries or other interactions to the Pride and Prejudice middleware components as JSON objects, and format data returned from Pride and Prejudice into what the user sees and interacts with.</p>
         <h3>Middleware</h3>

--- a/src/modules/records/components/KeywordSwitch/index.js
+++ b/src/modules/records/components/KeywordSwitch/index.js
@@ -1,3 +1,4 @@
+import './styles.css';
 import { Anchor, Icon } from '../../../reusable';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -22,31 +23,17 @@ const KeywordSwitch = ({ datastore, query }) => {
   };
 
   return (
-    <div
-      className={briefView ? 'record-preview' : 'container__rounded record'}
-      style={{
-        borderLeft: '4px solid var(--ds-color-maize-400)',
-        display: 'flex',
-        gap: '0.75rem',
-        padding: '1rem',
-        paddingLeft: '0.75rem'
-      }}
-    >
+    <div className={`flex padding__m padding-left__s ${briefView ? 'record-preview' : 'container__rounded record'} keyword-switch`}>
       <Icon
         d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z'
         size={24}
-        style={{
-          color: 'var(--ds-color-maize-500)',
-          flexShrink: '0'
-        }}
       />
       <div>
         <p className='no-margin'>
           {!briefView && isContainsSearch ? 'Seeing less precise results than you expected?' : 'Not seeing the results you expected?'}
-          <Anchor
-            to={`?query=${querySearch}`}
-            style={{ display: 'block' }}
-          >
+        </p>
+        <p className='no-margin'>
+          <Anchor to={`?query=${querySearch}`}>
             {linkText()}
           </Anchor>
         </p>

--- a/src/modules/records/components/KeywordSwitch/styles.css
+++ b/src/modules/records/components/KeywordSwitch/styles.css
@@ -1,0 +1,9 @@
+.keyword-switch {
+  border-left: 4px solid var(--ds-color-maize-400);
+  gap: 0.75rem;
+}
+
+.keyword-switch > svg {
+  color: var(--ds-color-maize-500);
+  flex-shrink: 0;
+}

--- a/src/modules/records/components/Record/index.js
+++ b/src/modules/records/components/Record/index.js
@@ -80,7 +80,7 @@ const Record = ({ datastoreUid, list, record }) => {
   return (
     <article className={`container__rounded record ${(isInList(list, record.uid) ? ' record--highlight' : '')}`}>
       <div className='record-container record-medium-container'>
-        <div className='record-title-and-actions-container '>
+        <div className='record-title-and-actions-container'>
           <Header {...{ datastoreUid, record }} />
           <AddToListButton item={record} />
         </div>
@@ -88,12 +88,7 @@ const Record = ({ datastoreUid, list, record }) => {
         <RecordMetadata {...{ record }} />
       </div>
 
-      <div
-        className='record-holders-container'
-        style={{
-          borderBottom: 'solid 1px var(--ds-color-neutral-100)'
-        }}
-      >
+      <div className='record-holders-container'>
         <h4 className='visually-hidden'>{record.names[0]} is available at:</h4>
         <ResourceAccess {...{ record }} />
       </div>

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -171,10 +171,7 @@ const FullRecord = () => {
           )}
         </div>
         <section aria-labelledby='available-at'>
-          <div
-            className='record-container'
-            style={{ paddingBottom: '0.25rem' }}
-          >
+          <div className='record-container padding-bottom__2xs'>
             <h2 className='full-record__record-info' id='available-at'>
               Available at:
             </h2>
@@ -204,8 +201,8 @@ const FullRecord = () => {
           return null;
         }
         return (
-          <p style={{ color: 'var(--search-color-grey-600)', marginTop: 0, order: 3 }}>
-            <span style={{ fontWeight: 600 }}>{indexingDate.name}:</span> {indexingDate.value}
+          <p className='margin-top__none text-grey full-record__date-last-indexed'>
+            <span className='strong'>{indexingDate.name}:</span> {indexingDate.value}
           </p>
         );
       })()}

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -166,7 +166,8 @@ const FullRecord = () => {
               {' '}
               anonymously if you encounter harmful or problematic language in catalog records or finding aids. More information about our policies and practices is available at
               {' '}
-              <Anchor href='https://www.lib.umich.edu/about-us/policies/remediation-harmful-language-library-metadata?utm_source=library-search'>Remediation of Harmful Language</Anchor>.
+              <Anchor href='https://www.lib.umich.edu/about-us/policies/remediation-harmful-language-library-metadata?utm_source=library-search'>Remediation of Harmful Language</Anchor>
+              .
             </p>
           )}
         </div>

--- a/src/modules/records/components/RecordPreview/index.js
+++ b/src/modules/records/components/RecordPreview/index.js
@@ -76,10 +76,7 @@ const Footer = ({ datastoreUid, record }) => {
   return (
     <>
       {outage && (
-        <p
-          className='margin-bottom__none margin-top__xs'
-          style={{ color: 'var(--search-color-red-300)' }}
-        >
+        <p className='margin-bottom__none margin-top__xs intent__error'>
           <Icon icon='warning' /> {outage}
         </p>
       )}

--- a/src/modules/records/components/Sorts/index.js
+++ b/src/modules/records/components/Sorts/index.js
@@ -47,7 +47,7 @@ const Sorts = ({ activeDatastore }) => {
 
   return (
     <div>
-      <label className='sorts-label sorts-label-text' htmlFor='sort-by' style={{ display: 'inline-block' }}>
+      <label className='sorts-label sorts-label-text' htmlFor='sort-by'>
         Sort by
       </label>
       <select

--- a/src/modules/resource-acccess/components/Holder/index.js
+++ b/src/modules/resource-acccess/components/Holder/index.js
@@ -44,7 +44,7 @@ const Holder = ({ captionLink, headings, notes, preExpanded, rows, ...rest }) =>
     <div {...rest}>
       {captionLink && (
         <p className='margin__none'>
-          <Anchor href={captionLink.href} style={{ color: 'var(--ds-color-neutral-400)' }}>
+          <Anchor href={captionLink.href} className='btn--tertiary'>
             {captionLink.text}
           </Anchor>
         </p>
@@ -79,10 +79,7 @@ const Holder = ({ captionLink, headings, notes, preExpanded, rows, ...rest }) =>
                 </ExpandableChildren>
                 {isExpandable && (
                   <tr>
-                    <td
-                      colSpan={`${rows[0].length}`}
-                      style={{ wordBreak: 'break-word' }}
-                    >
+                    <td colSpan={`${rows[0].length}`}>
                       <ExpandableButton count={rows.length} />
                     </td>
                   </tr>

--- a/src/modules/resource-acccess/components/Holding/index.js
+++ b/src/modules/resource-acccess/components/Holding/index.js
@@ -8,10 +8,7 @@ const Cell = ({ cell }) => {
       {cell.icon && (
         <Icon
           icon={cell.icon}
-          style={{
-            marginRight: '0.25rem',
-            marginTop: '-2px'
-          }}
+          className='margin-right__2xs'
         />
       )}
 

--- a/src/modules/reusable/components/Alert/styles.css
+++ b/src/modules/reusable/components/Alert/styles.css
@@ -23,6 +23,11 @@
   color: var(--search-color-orange-300);
 }
 
+.alert--flint {
+  align-items: center;
+  justify-content: center;
+}
+
 .alert a {
   color: inherit;
 }

--- a/src/modules/reusable/components/Metadata/index.js
+++ b/src/modules/reusable/components/Metadata/index.js
@@ -69,7 +69,7 @@ const Description = ({ data }) => {
       <ol className='list__unstyled'>
         {data.map((datum, index) => {
           return (
-            <li key={index} style={{ display: 'inline-block' }}>
+            <li key={index}>
               {index > 0 && <Icon icon='navigate_next' className='text-grey__light' />}
               <Description data={datum} />
             </li>
@@ -98,7 +98,6 @@ const Description = ({ data }) => {
           src={image}
           alt=''
           className='padding-top__xs'
-          style={{ maxWidth: '16rem' }}
         />
       )}
     </DescriptionItem>

--- a/src/modules/reusable/components/Metadata/styles.css
+++ b/src/modules/reusable/components/Metadata/styles.css
@@ -13,3 +13,11 @@
     max-width: 10rem;
   }
 }
+
+.metadata-details img {
+  max-width: 16rem;
+}
+
+.metadata-details ol.list__unstyled > li {
+  display: inline-block;
+}

--- a/src/modules/search/components/SearchResultsMessage/index.js
+++ b/src/modules/search/components/SearchResultsMessage/index.js
@@ -25,14 +25,7 @@ export default function SearchResultsMessage () {
       <p className='font-small margin__none'>
         You searched for: <span className='strong'>{original}</span>
       </p>
-      <span
-        className='flex parser-message font-small'
-        style={{
-          alignItems: 'baseline',
-          color: '#AA5600',
-          gap: '0.5rem'
-        }}
-      >
+      <span className='flex parser-message font-small intent__warning'>
         <div><Icon icon='warning' size={15} /></div>
         <p
           className='details-message'

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -793,6 +793,11 @@ details[open] > summary svg.expand_more {
   flex-grow: 1;
 }
 
+.parser-message {
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
 .parser-message p,
 .results-message p {
   margin: .25em 0;
@@ -1964,6 +1969,7 @@ body {
 }
 
 .sorts-label-text {
+  display: inline-block;
   padding-right: 0.5rem;
 }
 
@@ -2538,6 +2544,10 @@ input.get-this-field-input-year {
   }
 }
 
+.record-holders-container {
+  border-bottom: solid 1px var(--ds-color-neutral-100);
+}
+
 .lists-link-container {
   outline: solid 2px rgba(18, 109, 193, 0.6);
   z-index: 99;
@@ -2768,6 +2778,10 @@ input.get-this-field-input-year {
 
 .full-record__actions-container .lists-action {
   margin-top: 0.5rem;
+}
+
+.full-record__date-last-indexed {
+  order: 3;
 }
 
 .lists-actions__heading-tag {

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -122,7 +122,8 @@ body {
 /*
   Headings
 */
-h1 {
+h1,
+.h1 {
   font-size: 1.87rem;
 }
 
@@ -140,7 +141,8 @@ h3 {
   font-size: 1.25rem;
 }
 
-h4 {
+h4,
+.h4 {
   font-size: 1rem;
 }
 


### PR DESCRIPTION
# Overview
In an effort to keep files cleaner, non-dynamic inline styles have been separated by being added to their own `styles.css` import, or had utility classes added.

The next step is to break down `src/stylesheets/main.css` to figure out which styles are not used.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check the site to see if it looks funky.
