### PR TITLE
Bug: Advanced Search boolean types get deselected or cannot get reselected.

### DIFF
--- a/src/modules/advanced/reducer/index.js
+++ b/src/modules/advanced/reducer/index.js
@@ -88,7 +88,7 @@ const advancedFieldedSearchingReducer = (state, action) => {
           }
 
           return {
-            booleanType: booleanType ? booleanType : state[dsUid].fieldedSearches[index].booleanTypes,
+            booleanType: booleanType === undefined ? state[dsUid].fieldedSearches[index].booleanType : booleanType,
             field: selectedFieldUid || state[dsUid].fieldedSearches[index].field,
             query: newQuery
           };

--- a/src/modules/advanced/reducer/index.js
+++ b/src/modules/advanced/reducer/index.js
@@ -88,7 +88,7 @@ const advancedFieldedSearchingReducer = (state, action) => {
           }
 
           return {
-            booleanType: booleanType === undefined ? state[dsUid].fieldedSearches[index].booleanType : booleanType,
+            booleanType: typeof booleanType === 'number' && booleanType < 4 ? booleanType : state[dsUid].fieldedSearches[index].booleanType,
             field: selectedFieldUid || state[dsUid].fieldedSearches[index].field,
             query: newQuery
           };

--- a/src/modules/advanced/reducer/index.js
+++ b/src/modules/advanced/reducer/index.js
@@ -88,7 +88,7 @@ const advancedFieldedSearchingReducer = (state, action) => {
           }
 
           return {
-            booleanType: typeof booleanType === 'number' && booleanType < 4 ? booleanType : state[dsUid].fieldedSearches[index].booleanType,
+            booleanType: typeof booleanType === 'number' && booleanType < state.booleanTypes.length ? booleanType : state[dsUid].fieldedSearches[index].booleanType,
             field: selectedFieldUid || state[dsUid].fieldedSearches[index].field,
             query: newQuery
           };

--- a/src/stylesheets/forms.css
+++ b/src/stylesheets/forms.css
@@ -10,7 +10,7 @@ label:has(input[type='radio']):hover {
 input[type='radio'] {
   appearance: none;
   border: 2px solid var(--search-color-grey-600);
-  border-radius: 50%;
+  border-radius: 50%!important;
   height: 1.5rem;
   margin: -4px 0.25rem 0 0;
   position: relative;


### PR DESCRIPTION
# Overview
When adding multiple query options to search, when you start typing, the boolean type (`AND`, `OR`, `NOT`) disappears. You then cannot select `AND`. Two problems were discovered in the `reducer`:
1) `state[dsUid].fieldedSearches[index].booleanTypes` does not exist, making `booleanType` return `undefined`.
2) The `booleanType ? ...` ternary operator returns `false` when set to `AND` because the `value` of `AND` is `0`, which is also equivalent to `false`. It now specifically checks if it is a number and is less than the number of available boolean types to prevent the use of a magic number that does not exist as a type.

## Anything else?
Focusing on a radio button turned the button into a square. That is because of the `:focus` pseudo-class defining `border-radius: 2px`. Adding `border-radius: 50%!important` to the radio button resolves this style bug.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Go to [Advanced Search](http://localhost:3000/catalog/advanced), and type in multiple queries.
  - Can you select all redio buttons? Even with keyboard?
  - Do any of the radio selections disappear when you start typing?
  - Does search successfully run the full query?
