### PR TITLE
Styling `select` elements.

### DIFF
--- a/src/modules/advanced/components/FieldInput/index.js
+++ b/src/modules/advanced/components/FieldInput/index.js
@@ -43,7 +43,7 @@ const FieldInput = ({
       <div className='advanced-input-container'>
         <select
           aria-label={`Selected field ${fieldedSearchIndex + 1}`}
-          className='dropdown advanced-field-select'
+          className='advanced-field-select'
           value={fieldedSearch.field}
           onChange={(event) => {
             return changeFieldedSearch({

--- a/src/modules/advanced/components/NarrowSearchTo/index.js
+++ b/src/modules/advanced/components/NarrowSearchTo/index.js
@@ -20,7 +20,7 @@ const NarrowSearchTo = ({ handleChange, options }) => {
               {label}
             </label>
             <select
-              className='dropdown narrow-search-to-dropdown'
+              className='narrow-search-to-dropdown'
               id={slug}
               onChange={(event) => {
                 return handleChange({ uid: option.uid, value: event.target.value });

--- a/src/modules/datastores/components/Landing/index.js
+++ b/src/modules/datastores/components/Landing/index.js
@@ -64,7 +64,7 @@ const Landing = ({ activeDatastore, institution }) => {
             <h2 className='heading-large'>
               To find materials closest to you, please choose a library
             </h2>
-            <p>
+            <p className='flex flex__responsive'>
               {institution.options.map((library, index) => {
                 return (
                   <Anchor

--- a/src/modules/getthis/components/GetThisForm/index.js
+++ b/src/modules/getthis/components/GetThisForm/index.js
@@ -18,7 +18,7 @@ const Field = ({ field, loading, setFieldChange }) => {
         {field.label && (
           <label className='form-label' htmlFor={field.name}>{field.label}</label>
         )}
-        <select id={name} name={name} className='dropdown' value={value} onChange={setFieldChange} autoComplete='off'>
+        <select id={name} name={name} value={value} onChange={setFieldChange} autoComplete='off'>
           {options.map((option, key) => {
             return (
               <option

--- a/src/modules/institution/components/InstitutionSelect/index.js
+++ b/src/modules/institution/components/InstitutionSelect/index.js
@@ -1,3 +1,4 @@
+import './styles.css';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { stringifySearch } from '../../../search';
@@ -31,16 +32,15 @@ const InstitutionSelect = ({ activeDatastore, institution }) => {
   };
 
   return (
-    <fieldset className='institution-select-container'>
+    <fieldset className='institution-select-container margin-bottom__m padding-y__s padding-x__m'>
       <legend className='visually-hidden'>Institutions</legend>
       <label
-        className='institution-select-label institution-select-label-text'
+        className='institution-select-label-text'
         htmlFor='library-scope'
       >
         Library Scope
       </label>
       <select
-        className='dropdown'
         value={active || defaultInstitution}
         onChange={handleChange}
         id='library-scope'

--- a/src/modules/institution/components/InstitutionSelect/styles.css
+++ b/src/modules/institution/components/InstitutionSelect/styles.css
@@ -1,0 +1,14 @@
+.institution-select-container {
+  background: var(--search-color-grey-100);
+  border-radius: 4px;
+}
+
+.institution-select-container select {
+  width: 100%;
+}
+
+.institution-select-label-text {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}

--- a/src/modules/records/components/Sorts/index.js
+++ b/src/modules/records/components/Sorts/index.js
@@ -52,7 +52,7 @@ const Sorts = ({ activeDatastore }) => {
       </label>
       <select
         id='sort-by'
-        className='dropdown sorts-select'
+        className='sorts-select'
         value={sort[activeDatastore] || sorts[0].uid}
         onChange={handleOnChange}
         autoComplete='off'

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -82,7 +82,7 @@ const SearchBox = () => {
      * Get the dropdown's current value because `field` does not change
      * when switching to a different datastore, and the active datastore does not have the queried option
      */
-    const dropdown = document.querySelector('.search-box-dropdown > select.dropdown');
+    const dropdown = document.querySelector('select.search-box-dropdown');
     const dropdownOption = dropdown.value;
 
     // Change `field` to current dropdown value
@@ -132,23 +132,17 @@ const SearchBox = () => {
       }}
     >
       <div className='container container-medium'>
-        <div className='search-box-dropdown'>
-          <select
-            aria-label='Select an option'
-            className='dropdown'
-            value={currentField}
-            onChange={(event) => {
-              return setOption(event);
-            }}
-            autoComplete='off'
-          >
-            <SearchByOptions activeDatastore={activeDatastore} fields={fields} />
-          </select>
-          <Icon
-            icon='expand_more'
-            size={24}
-          />
-        </div>
+        <select
+          aria-label='Select an option'
+          className='search-box-dropdown'
+          value={currentField}
+          onChange={(event) => {
+            return setOption(event);
+          }}
+          autoComplete='off'
+        >
+          <SearchByOptions activeDatastore={activeDatastore} fields={fields} />
+        </select>
         <input
           type='text'
           aria-label={currentField.startsWith('browse_by_') ? 'Browse for' : 'Search for'}

--- a/src/modules/search/components/SearchBox/styles.css
+++ b/src/modules/search/components/SearchBox/styles.css
@@ -3,13 +3,6 @@
   border-bottom: solid 2px var(--search-color-blue-300);
 }
 
-.search-box-form *:focus {
-  border-radius: 2px;
-  box-shadow: var(--ds-color-maize-400) 0px 0px 0px 2px, var(--ds-color-blue-400) 0px 0px 0px 3px;
-  outline: 0;
-  z-index: 10;
-}
-
 .search-box-form > .container {
   display: grid;
   flex-direction: column;
@@ -47,33 +40,15 @@
 }
 
 .search-box-form > .container > .search-box-dropdown {
-  grid-area: dropdown;
-  position: relative;
-}
-
-.search-box-form > .container > .search-box-dropdown select {
-  all: unset;
-  background: var(--search-color-grey-100);
+  background-color: var(--search-color-grey-100);
   border: solid 1px var(--search-color-blue-400);
-  border-radius: 4px;
-  box-sizing: border-box;
-  height: 100%;
-  max-width: 100%;
+  grid-area: dropdown;
+  min-height: 2.5rem;
   padding: 0.5rem 0.75rem;
-  padding-right: 3rem;
-  width: 100%;
-}
-
-.search-box-form > .container > .search-box-dropdown > svg {
-  pointer-events: none;
-  position: absolute;
-  right: 0.5rem;
-  top: 50%;
-  transform: translateY(-50%);
 }
 
 @media (min-width: 640px) {
-  .search-box-form > .container > .search-box-dropdown select {
+  .search-box-form > .container > .search-box-dropdown {
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
   }

--- a/src/stylesheets/forms.css
+++ b/src/stylesheets/forms.css
@@ -46,7 +46,7 @@ select {
   color: inherit;
   cursor: pointer;
   font-family: inherit;
-  font-size: inherit;
+  font-size: 1rem;
   line-height: inherit;
   padding: 0.125rem 0.5rem;
   padding-right: 2rem;

--- a/src/stylesheets/forms.css
+++ b/src/stylesheets/forms.css
@@ -7,10 +7,14 @@ label:has(input[type='radio']):hover {
   text-decoration: underline;
 }
 
+input[type='radio'],
+input[type='radio']:before {
+  border-radius: 50%!important;
+}
+
 input[type='radio'] {
   appearance: none;
   border: 2px solid var(--search-color-grey-600);
-  border-radius: 50%!important;
   height: 1.5rem;
   margin: -4px 0.25rem 0 0;
   position: relative;
@@ -19,7 +23,6 @@ input[type='radio'] {
 }
 
 input[type='radio']:before {
-  border-radius: 50%;
   content: '';
   display: block;
   position: absolute;
@@ -32,4 +35,20 @@ input[type='radio']:before {
 
 input[type='radio']:checked:before {
   background: var(--search-color-blue-400);
+}
+
+select {
+  -webkit-appearance: none;
+  background: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="rgb(99, 115, 129)"><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/></svg>') calc(100% - 0.25rem) 50% no-repeat white;
+  border: solid 1px rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.08);
+  color: inherit;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  padding: 0.125rem 0.5rem;
+  padding-right: 2rem;
+  max-width: 100%;
 }

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -2169,34 +2169,10 @@ input.multiselect-search {
   margin-top: 0.125rem;
 }
 
-.institution-select-container {
-  background: #FAFAFA;
-  border-radius: 4px;
-  padding: 0.75rem 1rem;
-  margin-bottom: 1rem;
-}
-
-.institution-select-container .dropdown {
-  width: 100%;
-}
-
-.institution-select-label-text {
-  display: block;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
-}
-
 .institution-select-landing-container p {
-  display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   justify-content: center;
-}
-
-.institution-select-landing-heading {
-  font-weight: 400;
-  text-align: center;
-  margin-top: 0;
 }
 
 .radio-label {

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -748,22 +748,6 @@ details[open] > summary svg.expand_more {
   max-width: 1200px;
 }
 
-.dropdown,
-.dropdown-multiple {
-  font-size: 1rem;
-  font-family: "Noto Sans", sans-serif;
-  color: #262626;
-  line-height: 1.5;
-  background: white;
-  box-shadow: none;
-  cursor: pointer;
-  max-width: 100%;
-}
-
-.dropdown-multiple {
-  min-height: 10rem;
-}
-
 .card {
   box-shadow: 0 1px 10px rgba(0, 0, 0, 0.04);
   border-bottom: solid 2px #E5E5E5;

--- a/src/stylesheets/utilities.css
+++ b/src/stylesheets/utilities.css
@@ -1,3 +1,10 @@
+:focus,
+.focus:focus {
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px var(--color-maize-400), 0 0 0 3px var(--color-neutral-400)!important;
+  outline: 0;
+}
+
 .no-background {
   background: transparent;
   background-color: transparent;
@@ -49,10 +56,4 @@ a[class$="-checkbox"] > svg {
 
 a.active-checkbox > svg {
   color: var(--search-color-blue-400);
-}
-
-.focus:focus {
-  border-radius: 2px;
-  box-shadow: var(--ds-color-maize-400) 0px 0px 0px 2px, var(--ds-color-blue-400) 0px 0px 0px 3px;
-  outline: 0;
 }


### PR DESCRIPTION
# Overview
The `select` HTML element was the only remaining form element that did not have dedicated global styling. This pull request adds that and cleans up components that were using other styles and structures to help simplify.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check the site and see if `select` elements have the new styling and still work as intended.
