### PR TITLE
TDX 6898877: Library Search Feedback - poor display of multiple volumes

### DIFF
--- a/src/modules/resource-acccess/components/Holder/styles.css
+++ b/src/modules/resource-acccess/components/Holder/styles.css
@@ -10,6 +10,7 @@
 }
 
 .holder-container > table tr > * {
+  overflow-wrap: anywhere;
   padding: 0.5rem 0;
   width: auto;
 }


### PR DESCRIPTION
# Overview
Poorly formatted data does not wrap in Holdings, causing the text to overlap other cells. You can see [an example](https://search.lib.umich.edu/catalog/record/990039295180106381) under the last Buhr Shelving Facility accordion:

![image](https://github.com/user-attachments/assets/fe4ea513-c6fb-4e1e-a872-6a5575fcdf3a)

This pull request adds `overflow-wrap: anywhere` to the table cells, forcing wrapping to happen when appropriate. This resolves the [TDX Ticket 6898877](https://teamdynamix.umich.edu/TDNext/Apps/87/Tickets/TicketPeople?TicketID=6898877)

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check the live example above and compare it with the [dev example](https://deploy-preview-476--umich-lib-search-dev.netlify.app/catalog/record/990039295180106381?query=title%3A(Announcement.)&filter.author=University+of+Michigan.+Center+for+Japanese+Studies&filter.subject=University+of+Michigan&filter.format=Journal&filter.format=Serial), and confirm that the text wraps.
