### PR TITLE
[LIBSEARCH-958] Implement new availability filters in the UI

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -65,19 +65,11 @@ const config = {
       filters: [
         {
           conditions: {
-            checked: true
+            checked: true,
+            unchecked: undefined
           },
           groupBy: 'Access Options',
-          type: 'checkbox',
-          uid: 'available_online'
-        },
-        {
-          conditions: {
-            default: 'checked',
-            unchecked: false
-          },
-          groupBy: 'Access Options',
-          name: 'Remove Search Only HathiTrust Materials',
+          name: 'View HathiTrust search-only materials',
           type: 'checkbox',
           uid: 'search_only'
         },

--- a/src/config.js
+++ b/src/config.js
@@ -66,7 +66,7 @@ const config = {
         {
           conditions: {
             checked: true,
-            unchecked: undefined
+            unchecked: null
           },
           groupBy: 'Access Options',
           name: 'View HathiTrust search-only materials',

--- a/src/modules/filters/components/CheckboxFilters/index.js
+++ b/src/modules/filters/components/CheckboxFilters/index.js
@@ -25,13 +25,11 @@ const CheckBoxFilters = () => {
 
   return (
     <ul className='list__unstyled active-filters'>
-      {checkboxes.map((checkbox) => {
-        const { uid } = checkbox;
-        const { metadata, preSelected } = groups[uid];
-        const isActive = activeFilters[activeDatastore]?.[uid]?.[0];
-        const isChecked = isActive ? isActive === 'true' : preSelected;
+      {checkboxes.map(({ uid, metadata, preSelected }, index) => {
+        const [isActive] = activeFilters[activeDatastore]?.[uid] || [];
+        const isChecked = isActive === 'true' || preSelected;
         return (
-          <li key={uid}>
+          <li key={uid} className={`margin-top__${index === 0 ? 'none' : '2xs'}`}>
             <Anchor
               to={
                 preSelected === isChecked

--- a/src/modules/filters/components/CheckboxFilters/index.js
+++ b/src/modules/filters/components/CheckboxFilters/index.js
@@ -1,28 +1,30 @@
+import './styles.css';
 import { Anchor, Icon } from '../../../reusable';
 import { getURLWithFiltersRemoved, newSearch } from '../../utilities';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-const CheckBoxFiltersContainer = () => {
+const CheckBoxFilters = () => {
   const { active: activeFilters, groups, order } = useSelector((state) => {
     return state.filters;
   });
-  const activeDatastore = useSelector((state) => {
-    return state.datastores.active;
+  const { active: activeDatastore } = useSelector((state) => {
+    return state.datastores;
   });
-  const checkboxes = order.reduce((acc, id) => {
-    if (groups[id]?.type === 'checkbox') {
-      return acc.concat(groups[id]);
-    }
-    return acc;
-  }, []);
+  const checkboxes = order
+    .filter((id) => {
+      return groups[id]?.type === 'checkbox';
+    })
+    .map((id) => {
+      return groups[id];
+    });
 
   if (!checkboxes.length) {
     return null;
   }
 
   return (
-    <ul className='list__unstyled padding-y__s active-filters'>
+    <ul className='list__unstyled active-filters'>
       {checkboxes.map((checkbox) => {
         const { uid } = checkbox;
         const { metadata, preSelected } = groups[uid];
@@ -36,7 +38,7 @@ const CheckBoxFiltersContainer = () => {
                   ? `${document.location.pathname}?${newSearch({ filter: { [uid]: String(!isChecked) }, page: 1 })}`
                   : getURLWithFiltersRemoved({ group: uid, value: isActive })
               }
-              className={`padding-y__2xs padding-x__m flex underline__hover ${isChecked ? 'active-checkbox' : 'inactive-checkbox'}`}
+              className={`flex underline__hover ${isChecked ? '' : 'in'}active-checkbox`}
             >
               <Icon icon={`checkbox_${isChecked ? 'checked' : 'unchecked'}`} size='22' />
               {metadata.name}
@@ -48,4 +50,4 @@ const CheckBoxFiltersContainer = () => {
   );
 };
 
-export default CheckBoxFiltersContainer;
+export default CheckBoxFilters;

--- a/src/modules/filters/components/CheckboxFilters/styles.css
+++ b/src/modules/filters/components/CheckboxFilters/styles.css
@@ -1,0 +1,3 @@
+ul.active-filters {
+  padding: var(--search-spacing-s) var(--search-spacing-m);
+}

--- a/src/modules/resource-acccess/components/Holders/index.js
+++ b/src/modules/resource-acccess/components/Holders/index.js
@@ -22,6 +22,9 @@ const Holders = ({ context, record }) => {
         return row[0].text !== 'Search only (no full text)';
       });
     });
+    record.resourceAccess = record.resourceAccess.filter((resource) => {
+      return resource.rows.length > 0;
+    });
   }
   return (
     <>

--- a/src/modules/resource-acccess/components/Holders/index.js
+++ b/src/modules/resource-acccess/components/Holders/index.js
@@ -10,7 +10,7 @@ const Holders = ({ context, record }) => {
     return state.filters.active;
   });
   /*
-   * - Check if the record is under 'Catalog', and the 'Remove search-only HathiTrust materials' is checked
+   * - Check if the record is under 'Catalog', and the 'View search-only HathiTrust materials' is checked
    * - If true, remove all 'Search only (no full text)' holdings
    */
   if (
@@ -20,14 +20,11 @@ const Holders = ({ context, record }) => {
       || (Object.keys(mirlyn).includes('search_only') && mirlyn.search_only.includes('true'))
     )
   ) {
-    // UNCOMMENT THE BLOCK BELOW WHEN READY TO LAUNCH
-    /*
-     * Record.resourceAccess.forEach((resource) => {
-     *   resource.rows = resource.rows.filter((row) => {
-     *     return row[0].text !== 'Search only (no full text)';
-     *   });
-     * });
-     */
+    record.resourceAccess.forEach((resource) => {
+      resource.rows = resource.rows.filter((row) => {
+        return row[0].text !== 'Search only (no full text)';
+      });
+    });
   }
   return (
     <>

--- a/src/modules/resource-acccess/components/Holders/index.js
+++ b/src/modules/resource-acccess/components/Holders/index.js
@@ -10,15 +10,12 @@ const Holders = ({ context, record }) => {
     return state.filters.active;
   });
   /*
-   * - Check if the record is under 'Catalog', and the 'View search-only HathiTrust materials' is checked
+   * - Check if the record is under 'Catalog', and the 'View search-only HathiTrust materials' is unchecked
    * - If true, remove all 'Search only (no full text)' holdings
    */
   if (
     record.datastore === 'mirlyn'
-    && (
-      !mirlyn
-      || (Object.keys(mirlyn).includes('search_only') && mirlyn.search_only.includes('true'))
-    )
+    && (!mirlyn || !mirlyn.search_only || mirlyn.search_only.includes('false'))
   ) {
     record.resourceAccess.forEach((resource) => {
       resource.rows = resource.rows.filter((row) => {


### PR DESCRIPTION
# Overview
> It is currently “Remove search only HathiTrust materials” and checked by default.
> 
> We want to change it to “View HathiTrust search-only materials” and have it Unchecked by default

This pull request resolves [LIBSEARCH-958](https://mlit.atlassian.net/browse/LIBSEARCH-958).

