### PR TITLE
[LIBSEARCH-998] Add link to I.L.L. for the "no results" message in all four search types (part 2)

### DIFF
--- a/src/modules/affiliation/components/ChooseAffiliation/index.js
+++ b/src/modules/affiliation/components/ChooseAffiliation/index.js
@@ -43,9 +43,7 @@ const ChooseAffiliation = () => {
       affiliation: alternativeAffiliation
     };
     document.location.href
-      = `${document.location.pathname
-       }?${
-       stringifySearch(withAffiliation)}`;
+      = `${document.location.pathname}?${stringifySearch(withAffiliation)}`;
   };
 
   const [isDialogOpen, setDialogOpen] = useState(false);

--- a/src/modules/profile/components/Authentication/index.js
+++ b/src/modules/profile/components/Authentication/index.js
@@ -3,15 +3,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 const Authentication = ({ button, children, logout }) => {
+  const { pathname, search } = document.location;
   return (
     <Anchor
-      href={
-        `${process.env.REACT_APP_LOGIN_BASE_URL || window.location.origin
-         }/${
-         logout ? 'logout' : 'login'
-         }?dest=${
-         encodeURIComponent(document.location.pathname + document.location.search)}`
-      }
+      href={`${process.env.REACT_APP_LOGIN_BASE_URL || window.location.origin}/log${logout ? 'out' : 'in'}?dest=${encodeURIComponent(pathname + search)}`}
       className={button && 'button'}
     >
       {children || `Log ${logout ? 'out' : 'in'}`}

--- a/src/modules/records/components/BentoboxList/index.js
+++ b/src/modules/records/components/BentoboxList/index.js
@@ -1,5 +1,6 @@
 import { Anchor, Icon } from '../../../reusable';
 import { getMultiSearchRecords } from '../../../pride';
+import ILLRequestMessage from '../ILLRequestMessage';
 import KeywordSwitch from '../KeywordSwitch';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -33,6 +34,9 @@ const BentoResults = ({ bentobox, search, searchQuery }) => {
           <p className='no-margin'><span className='strong'>No results</span> match your search.</p>
           {['databases', 'onlinejournals'].includes(bentobox.uid) && (
             <p className='u-margin-bottom-none'>Try our <Anchor to={`/${bentobox.slug}/browse`}>Browse {bentobox.name} page</Anchor> to view all titles alphabetically or by academic discipline.</p>
+          )}
+          {bentobox.uid === 'mirlyn' && (
+            <p className='u-margin-bottom-none'><ILLRequestMessage /></p>
           )}
         </div>
       </>

--- a/src/modules/records/components/ILLRequestMessage/index.js
+++ b/src/modules/records/components/ILLRequestMessage/index.js
@@ -1,9 +1,10 @@
 import { Anchor } from '../../../reusable';
+import React from 'react';
 
 const ILLRequestMessage = () => {
   return (
     <>
-      Place an <Anchor href='https://ill.lib.umich.edu/' utmSource='library-search-no-items'>Interlibrary Loan request</Anchor> if you need something we don't have. We'll get it from another institution.
+      Place an <Anchor href='https://ill.lib.umich.edu/' utmSource='library-search-no-items'>Interlibrary Loan request</Anchor> if you need something we don&apos;t have. We&apos;ll get it from another institution.
     </>
   );
 };

--- a/src/modules/records/components/ILLRequestMessage/index.js
+++ b/src/modules/records/components/ILLRequestMessage/index.js
@@ -1,0 +1,11 @@
+import { Anchor } from '../../../reusable';
+
+const ILLRequestMessage = () => {
+  return (
+    <>
+      Place an <Anchor href='https://ill.lib.umich.edu/' utmSource='library-search-no-items'>Interlibrary Loan request</Anchor> if you need something we don't have. We'll get it from another institution.
+    </>
+  );
+};
+
+export default ILLRequestMessage;

--- a/src/modules/records/components/RecordList/index.js
+++ b/src/modules/records/components/RecordList/index.js
@@ -1,5 +1,6 @@
 import { Anchor } from '../../../reusable';
 import { GoToList } from '../../../lists';
+import ILLRequestMessage from '../ILLRequestMessage';
 import KeywordSwitch from '../KeywordSwitch';
 import React from 'react';
 import Record from '../Record';
@@ -58,7 +59,7 @@ const RecordList = () => {
                 <h2 className='heading-small margin-top__none'>Other suggestions</h2>
                 <ul className='margin-bottom__none'>
                   <li>Try looking at the other search categories linked below the search box.</li>
-                  <li>Place an <Anchor href='https://ill.lib.umich.edu/' utmSource='library-search-no-items'>Interlibrary Loan request</Anchor> if you need something we don't have. We'll get it from another institution.</li>
+                  <li><ILLRequestMessage /></li>
                   <li>Check your spelling.</li>
                   <li>Try more general keywords.</li>
                   <li>Try different keywords that mean the same thing.</li>

--- a/src/modules/records/index.js
+++ b/src/modules/records/index.js
@@ -12,6 +12,7 @@ import {
 import BentoboxList from './components/BentoboxList';
 import Bookplate from './components/Bookplate';
 import FullRecordPlaceholder from './components/FullRecordPlaceholder';
+import ILLRequestMessage from './components/ILLRequestMessage';
 import KeywordSwitch from './components/KeywordSwitch';
 import MARCTable from './components/MARCTable';
 import Pagination from './components/Pagination';
@@ -35,6 +36,7 @@ export {
   clearRecord,
   clearRecords,
   FullRecordPlaceholder,
+  ILLRequestMessage,
   KeywordSwitch,
   loadingHoldings,
   loadingRecords,


### PR DESCRIPTION
# Overview
The Interlibrary Loan request message for zero results also needed to be added to the Catalog section of Everything. To reduce repetition, the `ILLRequestMessage` component has been created and applied to wherever necessary.

This pull request closes [LIBSEARCH-998](https://mlit.atlassian.net/browse/LIBSEARCH-998).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Make a zero results search. Does the message appear in all datastores?
