### PR TITLE
Bug: Search initiated when no query 

### DIFF
--- a/src/modules/datastores/components/DatastoreRoute/index.js
+++ b/src/modules/datastores/components/DatastoreRoute/index.js
@@ -7,14 +7,9 @@ import React from 'react';
 const DatastoreRoute = () => {
   const { datastoreSlug } = useParams();
   const location = useLocation();
-  const { list } = config.datastores;
-  const slugDs = list.find((datastore) => {
-    return datastore.slug === datastoreSlug;
+  const isDatastore = config.datastores.list.some(({ slug, uid }) => {
+    return [slug, uid].includes(datastoreSlug);
   });
-  const uidDs = list.find((datastore) => {
-    return datastore.uid === datastoreSlug;
-  });
-  const isDatastore = Boolean(slugDs || uidDs);
   const urlState = getStateFromURL({ location });
 
   if (isDatastore && urlState) {


### PR DESCRIPTION
# Overview
> ...the Search front-end is producing spurious search queries to the backend.
>
> For example, loading the welcome page https://search.lib.umich.edu/ initiates searches.  It looks like it started in v1.15.35.

[v1.15.35](https://github.com/mlibrary/search/releases/tag/v1.15.35) was a major update, but the problem existed `URLSearchQueryWrapper`. It was updating whether or not the URL had any valid query parameters. The logic has been updated to check for parameters, and then run search of any of the `updateRequired` properties were `true`.

## Anything else?
* `DatastoreRoute` has been simplified.
* `datastoresUid` has been memoized to avoid unnecessary recalculations.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Run the site.
  - Does `/everything` no longer fetch every datastore from Spectrum?
  - Does the site still work when making changes to: filters, institution, page, query, sort?
