### PR TITLE
[LIBSEARCH-1029] Update Accessibility page to refer to "WCAG 2.1AA"

### DIFF
--- a/src/modules/pages/components/AccessibilityPage/index.js
+++ b/src/modules/pages/components/AccessibilityPage/index.js
@@ -12,7 +12,7 @@ const AccessibilityPage = () => {
       <main className='container__rounded page'>
         <H1 className='u-margin-top-none'>Accessibility</H1>
         <p>We are dedicated to creating inclusive services and products for all users. We are constantly working to make Library Search as accessible and usable as possible.</p>
-        <p>We aim to meet <Anchor href='https://www.w3.org/WAI/WCAG20/quickref/'>WCAG 2.0 AA standards</Anchor></p>
+        <p>We aim to meet <Anchor href='https://www.w3.org/TR/WCAG21/'>WCAG 2.1 AA standards</Anchor></p>
         <h2>Compatibility with tools</h2>
         <p>Library Search should be compatible with recent version of the following screen readers:</p>
         <ul>


### PR DESCRIPTION
# Overview
Updating WCAG standards to 2.1. Updated link to match [Lib's Accessibility page](https://lib.umich.edu/about-us/about-library/diversity-equity-inclusion-and-accessibility/accessibility).

This pull request closes [LIBSEARCH-1029](https://mlit.atlassian.net/browse/LIBSEARCH-1029).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check the [Accessibility](http://localhost:3000/accessibility) page and see if the text and link have been updated.