### PR TITLE
Adding permissions.

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,12 +4,11 @@ on:
   pull_request:
     types: [opened]
 
-permissions:
-  pull-requests: write
-
 jobs:
   update-title:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
     - name: Check conditions

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   update-title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When running the `dependabot` workflow, in `Update PR title`, this error gets produced:
```json
{
  "message": "Resource not accessible by integration",
  "documentation_url": "https://docs.github.com/rest/pulls/pulls#update-a-pull-request",
  "status": "403"
}
```

To help resolve the issue, we are adding permissions to the workflow.