### PR TITLE
[LIBSEARCH-801] Implement "clear active filters" designs for advanced search (Part 1)

### DIFF
--- a/src/modules/advanced/components/AdvancedSearchContainer/index.js
+++ b/src/modules/advanced/components/AdvancedSearchContainer/index.js
@@ -1,26 +1,42 @@
 import './styles.css';
-import { Breadcrumb, H1, Tab, TabPanel, Tabs } from '../../../reusable';
+import { Anchor, Breadcrumb, H1 } from '../../../reusable';
 import AdvancedSearchForm from '../AdvancedSearchForm';
 import React from 'react';
+import { stringifySearch } from '../../../search';
 import { useSelector } from 'react-redux';
 
 const AdvancedSearchContainer = () => {
-  const datastores = useSelector((state) => {
-    return state.datastores.datastores;
+  const { active: activeDatastoreUid, datastores } = useSelector((state) => {
+    return state.datastores;
   });
-  const activeDatastoreUid = useSelector((state) => {
-    return state.datastores.active;
+  const { page, query, sort } = useSelector((state) => {
+    return state.search;
   });
-  const activeDatastoreIndex = datastores.findIndex((datastore) => {
+  const { active: activeFilters } = useSelector((state) => {
+    return state.filters;
+  });
+  const { active: library } = useSelector((state) => {
+    return state.institution;
+  });
+  const activeDatastore = datastores.find((datastore) => {
     return datastore.uid === activeDatastoreUid;
   });
-  const activeDatastore = datastores[activeDatastoreIndex];
+  const queryString = (datastoreUid = activeDatastoreUid, nav) => {
+    const stringSearch = stringifySearch({
+      filter: activeFilters[datastoreUid],
+      library: datastoreUid === 'mirlyn' ? library : null,
+      page: nav || page[datastoreUid] === 1 ? null : page[datastoreUid],
+      query,
+      sort: sort[datastoreUid]
+    });
+    return stringSearch ? `?${stringSearch}` : '';
+  };
 
   return (
     <div className='container container-narrow margin-top__m'>
       <Breadcrumb
         items={[
-          { text: `${activeDatastore.name}`, to: `/${activeDatastore.slug}${document.location.search}` },
+          { text: `${activeDatastore.name}`, to: `/${activeDatastore.slug}${queryString()}` },
           { text: 'Advanced Search' }
         ]}
       />
@@ -28,22 +44,25 @@ const AdvancedSearchContainer = () => {
       <H1 className='heading-xlarge'>Advanced Search</H1>
       <p className='font-lede'>Select a search category below for associated advanced search options.</p>
 
-      <Tabs defaultActiveIndex={activeDatastoreIndex}>
-        {datastores.map((ds) => {
-          return (
-            <Tab key={`tab-${ds.uid}`}>
-              {ds.name}
-            </Tab>
-          );
-        })}
-        {datastores.map((ds) => {
-          return (
-            <TabPanel key={`panel-${ds.uid}`} className='tab-panel-container'>
-              <AdvancedSearchForm datastore={ds} />
-            </TabPanel>
-          );
-        })}
-      </Tabs>
+      <nav className='advanced-search-nav' aria-label='Advanced Search Datastores'>
+        <ol className='flex__responsive list__unstyled'>
+          {datastores.map((datastore) => {
+            return (
+              <li key={datastore.uid}>
+                <Anchor
+                  to={`/${datastore.slug}/advanced${queryString({ datastoreUid: datastore.uid, nav: true })}`}
+                  aria-current={activeDatastoreUid === datastore.uid && 'page'}
+                  className='underline__hover'
+                >
+                  {datastore.name}
+                </Anchor>
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
+      <AdvancedSearchForm datastore={activeDatastore} />
     </div>
   );
 };

--- a/src/modules/advanced/components/AdvancedSearchContainer/index.js
+++ b/src/modules/advanced/components/AdvancedSearchContainer/index.js
@@ -21,7 +21,7 @@ const AdvancedSearchContainer = () => {
   const activeDatastore = datastores.find((datastore) => {
     return datastore.uid === activeDatastoreUid;
   });
-  const queryString = (datastoreUid = activeDatastoreUid, nav) => {
+  const queryString = ({ datastoreUid, nav }) => {
     const stringSearch = stringifySearch({
       filter: activeFilters[datastoreUid],
       library: datastoreUid === 'mirlyn' ? library : null,
@@ -36,7 +36,7 @@ const AdvancedSearchContainer = () => {
     <div className='container container-narrow margin-top__m'>
       <Breadcrumb
         items={[
-          { text: `${activeDatastore.name}`, to: `/${activeDatastore.slug}${queryString()}` },
+          { text: `${activeDatastore.name}`, to: `/${activeDatastore.slug}${queryString({ datastoreUid: activeDatastoreUid })}` },
           { text: 'Advanced Search' }
         ]}
       />

--- a/src/modules/advanced/components/AdvancedSearchContainer/styles.css
+++ b/src/modules/advanced/components/AdvancedSearchContainer/styles.css
@@ -8,13 +8,14 @@
   border-width: 0 0 0 3px;
   display: block;
   height: 100%;
-  padding: 0.5rem 0.75rem;
+  padding: 0.5rem 1.5rem;
 }
 
 @media (min-width: 640px) {
   .advanced-search-nav a {
     border-radius: 4px 4px 0 0;
     border-width: 3px 0 0 0;
+    padding: 0.5rem 0.75rem;
   }
 }
 
@@ -26,6 +27,7 @@
 
 .advanced-search-nav a[aria-current="page"] {
   border-color: inherit;
+  font-weight: 600;
 }
 
 @media (min-width: 640px) {

--- a/src/modules/advanced/components/AdvancedSearchContainer/styles.css
+++ b/src/modules/advanced/components/AdvancedSearchContainer/styles.css
@@ -1,12 +1,63 @@
-.tab-panel-container {
-  box-shadow: rgba(0, 0, 0, 0.12) 0px 2px 2px 0px, rgba(0, 0, 0, 0.24) 0px 2px 4px 0px;
-  padding: 1rem;
-  background: var(--search-color-grey-100);
-  border-radius: 0 0 4px 4px;
+.advanced-search-nav ol {
+  gap: 0;
 }
 
-@media only screen and (min-width: 641px) {
-  .tab-panel-container {
-    padding: 2rem;
+.advanced-search-nav a {
+  border-color: var(--search-color-grey-400);
+  border-style: solid;
+  border-width: 0 0 0 3px;
+  display: block;
+  height: 100%;
+  padding: 0.5rem 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .advanced-search-nav a {
+    border-radius: 4px 4px 0 0;
+    border-width: 3px 0 0 0;
+  }
+}
+
+@media (min-width: 820px) {
+  .advanced-search-nav a {
+    padding: 0.5rem 1rem;
+  }
+}
+
+.advanced-search-nav a[aria-current="page"] {
+  border-color: inherit;
+}
+
+@media (min-width: 640px) {
+  .advanced-search-nav a[aria-current="page"] {
+    background-color: white;
+    box-shadow:
+      0 2px 2px 0 var(--search-color-grey-400),
+      0 2px 4px 0 var(--search-color-grey-400);
+    position: relative;
+  }
+
+  .advanced-search-nav a[aria-current="page"]:after {
+    content: '';
+    background-color: inherit;
+    bottom: -5px;
+    height: 5px;
+    left: -2px;
+    position: absolute;
+    right: -2px;
+  }
+
+  .advanced-search-nav li:first-child a[aria-current="page"]:after {
+    left: 0;
+  }
+}
+
+.advanced-search-nav a:not([aria-current="page"]) {
+  color: var(--search-color-grey-700);
+}
+
+@media (min-width: 640px) {
+  .advanced-search-nav a:not([aria-current="page"]) {
+    border-color: transparent;
   }
 }

--- a/src/modules/advanced/components/AdvancedSearchForm/index.js
+++ b/src/modules/advanced/components/AdvancedSearchForm/index.js
@@ -152,7 +152,7 @@ const AdvancedSearchForm = ({ datastore }) => {
         <Icon icon='search' size={24} /> Advanced Search
       </button>
 
-      <FiltersContainer datastore={datastore} />
+      <FiltersContainer datastoreUid={datastore.uid} />
     </form>
   );
 };

--- a/src/modules/advanced/components/AdvancedSearchForm/index.js
+++ b/src/modules/advanced/components/AdvancedSearchForm/index.js
@@ -1,9 +1,4 @@
-import './styles.css';
-import {
-  addFieldedSearch,
-  removeFieldedSearch,
-  setFieldedSearch
-} from '../../../advanced';
+import { addFieldedSearch, removeFieldedSearch, setFieldedSearch } from '../../../advanced';
 import { Alert, Icon } from '../../../reusable';
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -13,32 +8,31 @@ import PropTypes from 'prop-types';
 import { stringifySearch } from '../../../search';
 import { useNavigate } from 'react-router-dom';
 
+const removeUndefinedFilters = (object) => {
+  const filters = object || {};
+  Object.keys(filters).forEach((filter) => {
+    if (!filters[filter]) {
+      delete filters[filter];
+    }
+  });
+  return filters;
+};
+
 const AdvancedSearchForm = ({ datastore }) => {
   const navigate = useNavigate();
   const [errors, setErrors] = useState([]);
   const dispatch = useDispatch();
 
-  const fields = useSelector((state) => {
-    return state.advanced[datastore.uid].fields;
+  const { activeFilters: currentActiveFilters, fieldedSearches, fields } = useSelector((state) => {
+    return state.advanced[datastore.uid];
   });
-  const booleanTypes = useSelector((state) => {
-    return state.advanced.booleanTypes;
-  });
-  const fieldedSearches = useSelector((state) => {
-    return state.advanced[datastore.uid].fieldedSearches;
+  const { booleanTypes } = useSelector((state) => {
+    return state.advanced;
   });
   const institution = useSelector((state) => {
     return state.institution;
   });
-  const activeFilters = useSelector((state) => {
-    const currentFilters = state.advanced[datastore.uid].activeFilters || {};
-    Object.keys(currentFilters).forEach((filter) => {
-      if (!currentFilters[filter]) {
-        delete currentFilters[filter];
-      }
-    });
-    return currentFilters;
-  });
+  const activeFilters = removeUndefinedFilters(currentActiveFilters);
 
   // Functions wrapped with useCallback to prevent unnecessary re-creation
   const changeFieldedSearch = useCallback(({ booleanType, fieldedSearchIndex, query, selectedFieldUid }) => {
@@ -113,7 +107,7 @@ const AdvancedSearchForm = ({ datastore }) => {
   }, [navigate, institution, booleanTypes, fieldedSearches, activeFilters, datastore]);
 
   return (
-    <form className='y-spacing' onSubmit={handleSubmit}>
+    <form className='y-spacing container__rounded page margin-top__none' onSubmit={handleSubmit}>
       <h2 className='h1'>{datastore.name} Search</h2>
       {errors.map((error, index) => {
         return (
@@ -144,7 +138,7 @@ const AdvancedSearchForm = ({ datastore }) => {
         );
       })}
       <button
-        className='btn btn--small btn--secondary add-another-field'
+        className='btn btn--small btn--secondary margin-x__auto flex'
         onClick={handleAddAnotherFieldedSearch}
         type='button'
       >

--- a/src/modules/advanced/components/AdvancedSearchForm/styles.css
+++ b/src/modules/advanced/components/AdvancedSearchForm/styles.css
@@ -1,5 +1,0 @@
-.add-another-field {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-}

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -1781,10 +1781,6 @@ body {
   max-width: 32rem;
 }
 
-.advanced-search-form {
-  margin-bottom: 2rem;
-}
-
 .advanced-input {
   border: solid 1px rgba(0, 0, 0, 0.3);
 }

--- a/src/stylesheets/spacing.css
+++ b/src/stylesheets/spacing.css
@@ -105,6 +105,11 @@
   margin-left: var(--search-spacing-m);
 }
 
+.margin-x__auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .margin-x__none {
   margin-left: 0;
   margin-right: 0;

--- a/src/stylesheets/utilities.css
+++ b/src/stylesheets/utilities.css
@@ -14,8 +14,8 @@
   background-color: white;
   border-radius: 4px;
   box-shadow:
-    0 2px 2px 0 rgba(0, 0, 0, 0.12),
-    0 2px 4px 0 rgba(0, 0, 0, 0.24);
+    0 2px 2px 0 var(--search-color-grey-400),
+    0 2px 4px 0 var(--search-color-grey-400);
 }
 
 .flex,


### PR DESCRIPTION
# Overview
The current Advanced Search uses tabs to quickly navigate between each datastore option. However, it creates confusion because you may be on one datastore, but end up searching in a different datastore. We want to clarify which datastore you are on and pull in active filters from the datastore, with that also being reflected in the URL. We instead turn the tabs into links.

Some subtle styles have also been updated.

The next step is to take the datastore's active filters and have them reflected in the form on load.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Make a filtered search in multiple datastores. Go to Advanced search. Do you see the filter options in the URLs as you navigate?
  - Does it still look and feel similar to the live site?
