### PR TITLE
[LIBSEARCH-801] Implement "clear active filters" designs for advanced search (Part 2)

### DIFF
--- a/src/modules/advanced/components/AdvancedSearchContainer/index.js
+++ b/src/modules/advanced/components/AdvancedSearchContainer/index.js
@@ -47,14 +47,15 @@ const AdvancedSearchContainer = () => {
       <nav className='advanced-search-nav' aria-label='Advanced Search Datastores'>
         <ol className='flex__responsive list__unstyled'>
           {datastores.map((datastore) => {
+            const { name, slug, uid: datastoreUid } = datastore;
             return (
-              <li key={datastore.uid}>
+              <li key={datastoreUid}>
                 <Anchor
-                  to={`/${datastore.slug}/advanced${queryString({ datastoreUid: datastore.uid, nav: true })}`}
-                  aria-current={activeDatastoreUid === datastore.uid && 'page'}
+                  to={`/${slug}/advanced${queryString({ datastoreUid, nav: true })}`}
+                  aria-current={activeDatastoreUid === datastoreUid && 'page'}
                   className='underline__hover'
                 >
-                  {datastore.name}
+                  {name}
                 </Anchor>
               </li>
             );

--- a/src/modules/advanced/components/AdvancedSearchForm/index.js
+++ b/src/modules/advanced/components/AdvancedSearchForm/index.js
@@ -1,7 +1,7 @@
-import { addFieldedSearch, removeFieldedSearch } from '../../../advanced';
 import { Alert, Icon } from '../../../reusable';
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { addFieldedSearch } from '../../../advanced';
 import FieldInput from '../FieldInput';
 import FiltersContainer from '../FiltersContainer';
 import PropTypes from 'prop-types';
@@ -36,13 +36,6 @@ const AdvancedSearchForm = ({ datastore }) => {
       field: fields[0].uid
     }));
   }, [dispatch, datastore.uid, fields]);
-
-  const handleRemoveFieldedSearch = useCallback(({ removeIndex }) => {
-    dispatch(removeFieldedSearch({
-      datastoreUid: datastore.uid,
-      removeIndex
-    }));
-  }, [dispatch, datastore.uid]);
 
   const handleSubmit = useCallback((event) => {
     event.preventDefault();
@@ -114,9 +107,6 @@ const AdvancedSearchForm = ({ datastore }) => {
             fieldedSearchIndex={index}
             fieldedSearch={fs}
             fields={fields}
-            handleRemoveFieldedSearch={() => {
-              return handleRemoveFieldedSearch({ removeIndex: index });
-            }}
             activeDatastore={datastore}
           />
         );

--- a/src/modules/advanced/components/AdvancedSearchForm/index.js
+++ b/src/modules/advanced/components/AdvancedSearchForm/index.js
@@ -1,4 +1,4 @@
-import { addFieldedSearch, removeFieldedSearch, setFieldedSearch } from '../../../advanced';
+import { addFieldedSearch, removeFieldedSearch } from '../../../advanced';
 import { Alert, Icon } from '../../../reusable';
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -8,22 +8,12 @@ import PropTypes from 'prop-types';
 import { stringifySearch } from '../../../search';
 import { useNavigate } from 'react-router-dom';
 
-const removeUndefinedFilters = (object) => {
-  const filters = object || {};
-  Object.keys(filters).forEach((filter) => {
-    if (!filters[filter]) {
-      delete filters[filter];
-    }
-  });
-  return filters;
-};
-
 const AdvancedSearchForm = ({ datastore }) => {
   const navigate = useNavigate();
   const [errors, setErrors] = useState([]);
   const dispatch = useDispatch();
 
-  const { activeFilters: currentActiveFilters, fieldedSearches, fields } = useSelector((state) => {
+  const { activeFilters: currentActiveFilters = {}, fieldedSearches, fields } = useSelector((state) => {
     return state.advanced[datastore.uid];
   });
   const { booleanTypes } = useSelector((state) => {
@@ -32,18 +22,12 @@ const AdvancedSearchForm = ({ datastore }) => {
   const institution = useSelector((state) => {
     return state.institution;
   });
-  const activeFilters = removeUndefinedFilters(currentActiveFilters);
-
-  // Functions wrapped with useCallback to prevent unnecessary re-creation
-  const changeFieldedSearch = useCallback(({ booleanType, fieldedSearchIndex, query, selectedFieldUid }) => {
-    dispatch(setFieldedSearch({
-      booleanType,
-      datastoreUid: datastore.uid,
-      fieldedSearchIndex,
-      query,
-      selectedFieldUid
-    }));
-  }, [dispatch, datastore.uid]);
+  const activeFilters = Object.entries(currentActiveFilters).reduce((acc, [key, value]) => {
+    if (value) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
 
   const handleAddAnotherFieldedSearch = useCallback((event) => {
     event.preventDefault();
@@ -126,10 +110,10 @@ const AdvancedSearchForm = ({ datastore }) => {
         return (
           <FieldInput
             key={index}
+            booleanTypes={booleanTypes}
             fieldedSearchIndex={index}
             fieldedSearch={fs}
             fields={fields}
-            changeFieldedSearch={changeFieldedSearch}
             handleRemoveFieldedSearch={() => {
               return handleRemoveFieldedSearch({ removeIndex: index });
             }}

--- a/src/modules/advanced/components/AdvancedSearchForm/index.js
+++ b/src/modules/advanced/components/AdvancedSearchForm/index.js
@@ -100,18 +100,10 @@ const AdvancedSearchForm = ({ datastore }) => {
 
       <h3 className='offscreen'>Fielded search options</h3>
 
-      {fieldedSearches.map((fs, index) => {
-        return (
-          <FieldInput
-            key={index}
-            booleanTypes={booleanTypes}
-            fieldedSearchIndex={index}
-            fieldedSearch={fs}
-            fields={fields}
-            datastoreUid={datastoreUid}
-          />
-        );
+      {fieldedSearches.map((fieldedSearch, index) => {
+        return <FieldInput key={index} {...{ booleanTypes, datastoreUid, fieldedSearch, fieldedSearchIndex: index, fields }} />;
       })}
+
       <button
         className='btn btn--small btn--secondary margin-x__auto flex'
         onClick={handleAddAnotherFieldedSearch}
@@ -127,7 +119,7 @@ const AdvancedSearchForm = ({ datastore }) => {
         <Icon icon='search' size={24} /> Advanced Search
       </button>
 
-      <FiltersContainer datastoreUid={datastoreUid} />
+      <FiltersContainer {...{ datastoreUid }} />
     </form>
   );
 };

--- a/src/modules/advanced/components/AdvancedSearchForm/index.js
+++ b/src/modules/advanced/components/AdvancedSearchForm/index.js
@@ -12,9 +12,10 @@ const AdvancedSearchForm = ({ datastore }) => {
   const navigate = useNavigate();
   const [errors, setErrors] = useState([]);
   const dispatch = useDispatch();
+  const { name, slug, uid: datastoreUid } = datastore;
 
   const { activeFilters: currentActiveFilters = {}, fieldedSearches, fields } = useSelector((state) => {
-    return state.advanced[datastore.uid];
+    return state.advanced[datastoreUid];
   });
   const { booleanTypes } = useSelector((state) => {
     return state.advanced;
@@ -32,10 +33,10 @@ const AdvancedSearchForm = ({ datastore }) => {
   const handleAddAnotherFieldedSearch = useCallback((event) => {
     event.preventDefault();
     dispatch(addFieldedSearch({
-      datastoreUid: datastore.uid,
+      datastoreUid,
       field: fields[0].uid
     }));
-  }, [dispatch, datastore.uid, fields]);
+  }, [dispatch, datastoreUid, fields]);
 
   const handleSubmit = useCallback((event) => {
     event.preventDefault();
@@ -64,7 +65,7 @@ const AdvancedSearchForm = ({ datastore }) => {
         query
       };
 
-      if (datastore.uid === 'mirlyn') {
+      if (datastoreUid === 'mirlyn') {
         if (search.filter.institution) {
           const { institution: [firstInstitution] } = search.filter;
           search.library = firstInstitution;
@@ -74,7 +75,7 @@ const AdvancedSearchForm = ({ datastore }) => {
         }
       }
 
-      navigate(`/${datastore.slug}?${stringifySearch(search)}`);
+      navigate(`/${slug}?${stringifySearch(search)}`);
     } else {
       setErrors([
         'A search term or option is required to submit an advanced search.'
@@ -85,7 +86,7 @@ const AdvancedSearchForm = ({ datastore }) => {
 
   return (
     <form className='y-spacing container__rounded page margin-top__none' onSubmit={handleSubmit}>
-      <h2 className='h1'>{datastore.name} Search</h2>
+      <h2 className='h1'>{name} Search</h2>
       {errors.map((error, index) => {
         return (
           <Alert type='error' key={index}>
@@ -107,7 +108,7 @@ const AdvancedSearchForm = ({ datastore }) => {
             fieldedSearchIndex={index}
             fieldedSearch={fs}
             fields={fields}
-            activeDatastore={datastore}
+            datastoreUid={datastoreUid}
           />
         );
       })}
@@ -126,7 +127,7 @@ const AdvancedSearchForm = ({ datastore }) => {
         <Icon icon='search' size={24} /> Advanced Search
       </button>
 
-      <FiltersContainer datastoreUid={datastore.uid} />
+      <FiltersContainer datastoreUid={datastoreUid} />
     </form>
   );
 };

--- a/src/modules/advanced/components/FieldInput/index.js
+++ b/src/modules/advanced/components/FieldInput/index.js
@@ -6,8 +6,8 @@ import SearchByOptions from '../../../search/components/SearchByOptions';
 import { useDispatch } from 'react-redux';
 
 const FieldInput = ({
-  activeDatastore,
   booleanTypes,
+  datastoreUid,
   fieldedSearch,
   fieldedSearchIndex,
   fields
@@ -20,11 +20,11 @@ const FieldInput = ({
     (update) => {
       dispatch(setFieldedSearch({
         ...update,
-        datastoreUid: activeDatastore.uid,
+        datastoreUid,
         fieldedSearchIndex
       }));
     },
-    [dispatch, activeDatastore.uid, fieldedSearchIndex]
+    [dispatch, datastoreUid, fieldedSearchIndex]
   );
 
   const handleBooleanTypeChange = useCallback(
@@ -51,11 +51,11 @@ const FieldInput = ({
   const handleRemoveFieldedSearch = useCallback(
     () => {
       dispatch(removeFieldedSearch({
-        datastoreUid: activeDatastore.uid,
+        datastoreUid,
         removeIndex: fieldedSearchIndex
       }));
     },
-    [dispatch, activeDatastore.uid, fieldedSearchIndex]
+    [dispatch, datastoreUid, fieldedSearchIndex]
   );
 
   return (
@@ -90,7 +90,7 @@ const FieldInput = ({
           onChange={handleFieldChange}
           autoComplete='off'
         >
-          <SearchByOptions activeDatastore={activeDatastore} fields={fields} />
+          <SearchByOptions datastoreUid={datastoreUid} fields={fields} />
         </select>
         <div className='advanced-input-remove-container'>
           <input
@@ -120,8 +120,8 @@ const FieldInput = ({
 };
 
 FieldInput.propTypes = {
-  activeDatastore: PropTypes.object,
   booleanTypes: PropTypes.array,
+  datastoreUid: PropTypes.string,
   fieldedSearch: PropTypes.object,
   fieldedSearchIndex: PropTypes.number,
   fields: PropTypes.array

--- a/src/modules/advanced/components/FieldInput/index.js
+++ b/src/modules/advanced/components/FieldInput/index.js
@@ -1,8 +1,8 @@
 import React, { memo, useCallback } from 'react';
+import { removeFieldedSearch, setFieldedSearch } from '../../../advanced';
 import Icon from '../../../reusable/components/Icon';
 import PropTypes from 'prop-types';
 import SearchByOptions from '../../../search/components/SearchByOptions';
-import { setFieldedSearch } from '../../../advanced';
 import { useDispatch } from 'react-redux';
 
 const FieldInput = ({
@@ -10,37 +10,53 @@ const FieldInput = ({
   booleanTypes,
   fieldedSearch,
   fieldedSearchIndex,
-  fields,
-  handleRemoveFieldedSearch
+  fields
 }) => {
   const dispatch = useDispatch();
 
   const notFirst = fieldedSearchIndex > 0;
 
   const changeFieldedSearch = useCallback(
-    ({ booleanType, query, selectedFieldUid }) => {
+    (update) => {
       dispatch(setFieldedSearch({
-        booleanType,
+        ...update,
         datastoreUid: activeDatastore.uid,
-        fieldedSearchIndex,
-        query,
-        selectedFieldUid
+        fieldedSearchIndex
       }));
     },
     [dispatch, activeDatastore.uid, fieldedSearchIndex]
   );
 
-  const handleBooleanTypeChange = useCallback((index) => {
-    changeFieldedSearch({ booleanType: index });
-  }, [changeFieldedSearch]);
+  const handleBooleanTypeChange = useCallback(
+    (index) => {
+      changeFieldedSearch({ booleanType: index });
+    },
+    [changeFieldedSearch]
+  );
 
-  const handleFieldChange = useCallback((event) => {
-    changeFieldedSearch({ selectedFieldUid: event.target.value });
-  }, [changeFieldedSearch]);
+  const handleFieldChange = useCallback(
+    (event) => {
+      changeFieldedSearch({ selectedFieldUid: event.target.value });
+    },
+    [changeFieldedSearch]
+  );
 
-  const handleQueryChange = useCallback((event) => {
-    changeFieldedSearch({ query: event.target.value });
-  }, [changeFieldedSearch]);
+  const handleQueryChange = useCallback(
+    (event) => {
+      changeFieldedSearch({ query: event.target.value });
+    },
+    [changeFieldedSearch]
+  );
+
+  const handleRemoveFieldedSearch = useCallback(
+    () => {
+      dispatch(removeFieldedSearch({
+        datastoreUid: activeDatastore.uid,
+        removeIndex: fieldedSearchIndex
+      }));
+    },
+    [dispatch, activeDatastore.uid, fieldedSearchIndex]
+  );
 
   return (
     <fieldset className='y-spacing advanced-fieldset'>
@@ -108,8 +124,7 @@ FieldInput.propTypes = {
   booleanTypes: PropTypes.array,
   fieldedSearch: PropTypes.object,
   fieldedSearchIndex: PropTypes.number,
-  fields: PropTypes.array,
-  handleRemoveFieldedSearch: PropTypes.func
+  fields: PropTypes.array
 };
 
 export default memo(FieldInput);

--- a/src/modules/advanced/components/FieldInput/index.js
+++ b/src/modules/advanced/components/FieldInput/index.js
@@ -96,7 +96,6 @@ const FieldInput = ({
           <input
             type='text'
             value={fieldedSearch.query}
-            data-hj-allow
             onChange={handleQueryChange}
             autoComplete='on'
             aria-label={`Search Term ${fieldedSearchIndex + 1}`}

--- a/src/modules/advanced/components/FieldInput/index.js
+++ b/src/modules/advanced/components/FieldInput/index.js
@@ -1,17 +1,46 @@
+import React, { memo, useCallback } from 'react';
 import Icon from '../../../reusable/components/Icon';
 import PropTypes from 'prop-types';
-import React from 'react';
 import SearchByOptions from '../../../search/components/SearchByOptions';
+import { setFieldedSearch } from '../../../advanced';
+import { useDispatch } from 'react-redux';
 
 const FieldInput = ({
   activeDatastore,
-  changeFieldedSearch,
+  booleanTypes,
   fieldedSearch,
   fieldedSearchIndex,
   fields,
   handleRemoveFieldedSearch
 }) => {
+  const dispatch = useDispatch();
+
   const notFirst = fieldedSearchIndex > 0;
+
+  const changeFieldedSearch = useCallback(
+    ({ booleanType, query, selectedFieldUid }) => {
+      dispatch(setFieldedSearch({
+        booleanType,
+        datastoreUid: activeDatastore.uid,
+        fieldedSearchIndex,
+        query,
+        selectedFieldUid
+      }));
+    },
+    [dispatch, activeDatastore.uid, fieldedSearchIndex]
+  );
+
+  const handleBooleanTypeChange = useCallback((index) => {
+    changeFieldedSearch({ booleanType: index });
+  }, [changeFieldedSearch]);
+
+  const handleFieldChange = useCallback((event) => {
+    changeFieldedSearch({ selectedFieldUid: event.target.value });
+  }, [changeFieldedSearch]);
+
+  const handleQueryChange = useCallback((event) => {
+    changeFieldedSearch({ query: event.target.value });
+  }, [changeFieldedSearch]);
 
   return (
     <fieldset className='y-spacing advanced-fieldset'>
@@ -19,7 +48,7 @@ const FieldInput = ({
       {notFirst && (
         <fieldset className='flex__responsive'>
           <legend className='visually-hidden'>Boolean operator for field {fieldedSearchIndex} and field {fieldedSearchIndex + 1}</legend>
-          {['AND', 'OR', 'NOT'].map((option, index) => {
+          {booleanTypes.map((option, index) => {
             return (
               <label key={index}>
                 <input
@@ -28,10 +57,7 @@ const FieldInput = ({
                   value={option}
                   checked={fieldedSearch.booleanType === index}
                   onChange={() => {
-                    return changeFieldedSearch({
-                      booleanType: index,
-                      fieldedSearchIndex
-                    });
+                    return handleBooleanTypeChange(index);
                   }}
                 />
                 {option}
@@ -45,12 +71,7 @@ const FieldInput = ({
           aria-label={`Selected field ${fieldedSearchIndex + 1}`}
           className='advanced-field-select'
           value={fieldedSearch.field}
-          onChange={(event) => {
-            return changeFieldedSearch({
-              fieldedSearchIndex,
-              selectedFieldUid: event.target.value
-            });
-          }}
+          onChange={handleFieldChange}
           autoComplete='off'
         >
           <SearchByOptions activeDatastore={activeDatastore} fields={fields} />
@@ -60,12 +81,7 @@ const FieldInput = ({
             type='text'
             value={fieldedSearch.query}
             data-hj-allow
-            onChange={(event) => {
-              return changeFieldedSearch({
-                fieldedSearchIndex,
-                query: event.target.value
-              });
-            }}
+            onChange={handleQueryChange}
             autoComplete='on'
             aria-label={`Search Term ${fieldedSearchIndex + 1}`}
           />
@@ -89,11 +105,11 @@ const FieldInput = ({
 
 FieldInput.propTypes = {
   activeDatastore: PropTypes.object,
-  changeFieldedSearch: PropTypes.func,
+  booleanTypes: PropTypes.array,
   fieldedSearch: PropTypes.object,
   fieldedSearchIndex: PropTypes.number,
   fields: PropTypes.array,
   handleRemoveFieldedSearch: PropTypes.func
 };
 
-export default FieldInput;
+export default memo(FieldInput);

--- a/src/modules/reusable/components/Breadcrumb/index.js
+++ b/src/modules/reusable/components/Breadcrumb/index.js
@@ -6,9 +6,10 @@ const Breadcrumb = ({ items }) => {
   return (
     <ol className='breadcrumb'>
       {items.map((item, index) => {
+        const { href, text, to } = item;
         return (
           <li className='breadcrumb__item' key={index}>
-            {(item.href || item.to) ? <Anchor href={item.href} to={item.to}>{item.text}</Anchor> : item.text}
+            {(href || to) ? <Anchor {...{ href, to }}>{text}</Anchor> : text}
           </li>
         );
       })}

--- a/src/modules/search/components/SearchBox/index.js
+++ b/src/modules/search/components/SearchBox/index.js
@@ -141,7 +141,7 @@ const SearchBox = () => {
           }}
           autoComplete='off'
         >
-          <SearchByOptions activeDatastore={activeDatastore} fields={fields} />
+          <SearchByOptions datastoreUid={activeDatastore.uid} fields={fields} />
         </select>
         <input
           type='text'

--- a/src/modules/search/components/SearchByOptions/index.js
+++ b/src/modules/search/components/SearchByOptions/index.js
@@ -17,12 +17,12 @@ const listOptions = (options) => {
   });
 };
 
-const SearchByOptions = ({ activeDatastore, fields }) => {
+const SearchByOptions = ({ datastoreUid, fields }) => {
   let setFields = fields;
   // Override fields if custom options exist for current datastore
-  if (searchOptionsDatastores().includes(activeDatastore.uid)) {
+  if (searchOptionsDatastores().includes(datastoreUid)) {
     setFields = searchOptions().filter((searchOption) => {
-      return searchOption.datastore.includes(activeDatastore.uid);
+      return searchOption.datastore.includes(datastoreUid);
     });
   }
   const searchByOptions = filterOptions(setFields);
@@ -44,7 +44,7 @@ const SearchByOptions = ({ activeDatastore, fields }) => {
 };
 
 SearchByOptions.propTypes = {
-  activeDatastore: PropTypes.object,
+  datastoreUid: PropTypes.string,
   fields: PropTypes.array
 };
 


### PR DESCRIPTION
# Overview
This pull request focuses on increasing performance of the overall Advanced Search pages. Below are the noted changes:
- `removeFieldedSearch`, and `setFieldedSearch` have been moved to `FieldInput` as those functions are only ever handled in that component.
- `removeUndefinedFilters` logic has been updated and applied directly to `activeFilters`.
- `FieldInput` and `SearchByOptions` only ever use the `uid` of the current datastore. Instead of passing in the entire object, only the string gets passed in.
- Object destructuring to reduce repeated code.
- Wrapped `FieldInput` in `memo` to prevent unnecessary re-renders when the props haven't changed.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Go to Advanced Search. Doe everything work as expected?
