### PR TITLE
[LIBSEARCH-801] Implement "clear active filters" designs for advanced search (Part 4)

### DIFF
--- a/src/modules/advanced/components/AdvancedFilter/index.js
+++ b/src/modules/advanced/components/AdvancedFilter/index.js
@@ -1,5 +1,4 @@
 import { Checkbox } from '../../../reusable';
-import { DateRangeInput } from '../../../core';
 import NarrowSearchTo from '../NarrowSearchTo';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -16,82 +15,6 @@ const getIsCheckboxFilterChecked = ({ advancedFilter }) => {
   }
 
   return false;
-};
-
-const getDateRangeValue = ({ beginDateQuery, endDateQuery, selectedRange }) => {
-  switch (selectedRange) {
-    case 'Before':
-      if (endDateQuery) {
-        return `before ${endDateQuery}`;
-      }
-      return null;
-    case 'After':
-      if (beginDateQuery) {
-        return `after ${beginDateQuery}`;
-      }
-      return null;
-    case 'Between':
-      if (beginDateQuery && endDateQuery) {
-        return `${beginDateQuery} to ${endDateQuery}`;
-      }
-      return null;
-    case 'In':
-      if (beginDateQuery) {
-        return beginDateQuery;
-      }
-      return null;
-    default:
-      return null;
-  }
-};
-
-const getStateDateRangeValues = ({ advancedFilter }) => {
-  if (advancedFilter.activeFilters?.length > 0) {
-    const [filterValue] = advancedFilter.activeFilters;
-
-    // Before
-    if (filterValue.indexOf('before') !== -1) {
-      const values = filterValue.split('before');
-
-      return {
-        stateEndQuery: values[1],
-        stateSelectedRangeOption: 0
-      };
-    }
-
-    // After
-    if (filterValue.indexOf('after') !== -1) {
-      const values = filterValue.split('after');
-
-      return {
-        stateBeginQuery: values[1],
-        stateSelectedRangeOption: 1
-      };
-    }
-
-    // Between
-    if (filterValue.indexOf('to') !== -1) {
-      const values = filterValue.split('to');
-
-      return {
-        stateBeginQuery: values[0],
-        stateEndQuery: values[1],
-        stateSelectedRangeOption: 2
-      };
-    }
-
-    // In or other
-    return {
-      stateBeginQuery: filterValue,
-      stateSelectedRangeOption: 3
-    };
-  }
-
-  return {
-    stateBeginQuery: '',
-    stateEndQuery: '',
-    stateSelectedRangeOption: 0
-  };
 };
 
 const AdvancedFilter = ({ advancedFilter, changeAdvancedFilter }) => {
@@ -124,24 +47,6 @@ const AdvancedFilter = ({ advancedFilter, changeAdvancedFilter }) => {
         }}
         isChecked={isChecked}
         label={advancedFilter.name}
-      />
-    );
-  }
-  if (advancedFilter.type === 'date_range_input') {
-    const { stateSelectedRangeOption, stateBeginQuery, stateEndQuery } = getStateDateRangeValues({ advancedFilter });
-
-    return (
-      <DateRangeInput
-        selectedRangeOption={stateSelectedRangeOption}
-        beginQuery={stateBeginQuery}
-        endQuery={stateEndQuery}
-        handleSelection={({ beginDateQuery, endDateQuery, selectedRange }) => {
-          return changeAdvancedFilter({
-            filterGroupUid: advancedFilter.uid,
-            filterType: advancedFilter.type,
-            filterValue: getDateRangeValue({ beginDateQuery, endDateQuery, selectedRange })
-          });
-        }}
       />
     );
   }

--- a/src/modules/advanced/components/FiltersContainer/index.js
+++ b/src/modules/advanced/components/FiltersContainer/index.js
@@ -9,7 +9,10 @@ import React from 'react';
 
 const FiltersContainer = ({ datastoreUid }) => {
   const dispatch = useDispatch();
-  const { activeFilters, filters: filterGroups } = useSelector((state) => {
+  const { [datastoreUid]: urlFilters = {} } = useSelector((state) => {
+    return state.filters.active;
+  });
+  const { activeFilters = {}, filters: filterGroups } = useSelector((state) => {
     return state.advanced[datastoreUid] || {};
   });
   const advancedDatastoreFilters = getFilters({ activeFilters, filterGroups });
@@ -73,12 +76,23 @@ const FiltersContainer = ({ datastoreUid }) => {
                 ? (
                     advancedDatastoreFilters[filterGroup].map((advancedFilter, index) => {
                       const { filters, name, type, uid } = advancedFilter;
+                      const currentAdvancedFilters = activeFilters[uid] || [];
+                      const currentURLFilters = urlFilters[uid] || [];
+                      // Make sure the URL filters and the advanced filters match on load
+                      const currentFilters = [
+                        ...currentURLFilters.filter((currentURLFilter) => {
+                          return !currentAdvancedFilters.includes(currentURLFilter);
+                        }),
+                        ...currentAdvancedFilters.filter((currentAdvancedFilter) => {
+                          return !currentURLFilters.includes(currentAdvancedFilter);
+                        })
+                      ];
                       return (
                         <div key={index} className='advanced-filter-container'>
                           <h2 className='advanced-filter-label-text'>{name}</h2>
                           <div className='advanced-filter-inner-container'>
-                            {type === 'multiple_select' && <Multiselect {...{ datastoreUid, filterGroupUid: uid, filters, name }} />}
-                            {type === 'date_range_input' && <DateRangeInput {...{ datastoreUid, filterGroupUid: uid }} />}
+                            {type === 'multiple_select' && <Multiselect {...{ currentFilters, datastoreUid, filterGroupUid: uid, filters, name }} />}
+                            {type === 'date_range_input' && <DateRangeInput {...{ currentFilters, datastoreUid, filterGroupUid: uid }} />}
                             {!['multiple_select', 'date_range_input'].includes(type) && <AdvancedFilter {...{ advancedFilter, changeAdvancedFilter }} />}
                           </div>
                         </div>

--- a/src/modules/advanced/components/FiltersContainer/index.js
+++ b/src/modules/advanced/components/FiltersContainer/index.js
@@ -92,7 +92,7 @@ const FiltersContainer = ({ datastoreUid }) => {
                           <h2 className='advanced-filter-label-text'>{name}</h2>
                           <div className='advanced-filter-inner-container'>
                             {type === 'multiple_select' && <Multiselect {...{ currentFilters, datastoreUid, filterGroupUid: uid, filters, name }} />}
-                            {type === 'date_range_input' && <DateRangeInput {...{ currentFilters, datastoreUid, filterGroupUid: uid }} />}
+                            {type === 'date_range_input' && <DateRangeInput {...{ currentFilter: currentURLFilters[0], datastoreUid, filterGroupUid: uid }} />}
                             {!['multiple_select', 'date_range_input'].includes(type) && <AdvancedFilter {...{ advancedFilter, changeAdvancedFilter }} />}
                           </div>
                         </div>

--- a/src/modules/advanced/components/FiltersContainer/index.js
+++ b/src/modules/advanced/components/FiltersContainer/index.js
@@ -1,9 +1,9 @@
 import { AdvancedSearchSubmit, setAdvancedFilter } from '../../../advanced';
+import { DateRangeInput, Multiselect } from '../../../core';
 import { useDispatch, useSelector } from 'react-redux';
 import ActiveAdvancedFilters from '../ActiveAdvancedFilters';
 import AdvancedFilter from '../AdvancedFilter';
 import getFilters from './getFilters';
-import { Multiselect } from '../../../core';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -43,7 +43,6 @@ const FiltersContainer = ({ datastoreUid }) => {
         }));
         break;
       case 'checkbox':
-      case 'date_range_input':
         dispatch(setAdvancedFilter({
           datastoreUid,
           filterGroupUid,
@@ -78,9 +77,9 @@ const FiltersContainer = ({ datastoreUid }) => {
                         <div key={index} className='advanced-filter-container'>
                           <h2 className='advanced-filter-label-text'>{name}</h2>
                           <div className='advanced-filter-inner-container'>
-                            {type === 'multiple_select'
-                              ? <Multiselect {...{ datastoreUid, filterGroupUid: uid, filters, name }} />
-                              : <AdvancedFilter {...{ advancedFilter, changeAdvancedFilter }} />}
+                            {type === 'multiple_select' && <Multiselect {...{ datastoreUid, filterGroupUid: uid, filters, name }} />}
+                            {type === 'date_range_input' && <DateRangeInput {...{ datastoreUid, filterGroupUid: uid }} />}
+                            {!['multiple_select', 'date_range_input'].includes(type) && <AdvancedFilter {...{ advancedFilter, changeAdvancedFilter }} />}
                           </div>
                         </div>
                       );

--- a/src/modules/core/components/DateRangeInput/index.js
+++ b/src/modules/core/components/DateRangeInput/index.js
@@ -44,9 +44,7 @@ const DateRangeInput = ({ currentFilter = '', datastoreUid, filterGroupUid }) =>
 
   useEffect(() => {
     let filterValue = '';
-    if (years.some((year) => {
-      return year;
-    })) {
+    if (years.some(Boolean)) {
       if (range === 'between') {
         filterValue = years.filter(Number).join(' to ');
       } else {

--- a/src/modules/core/components/DateRangeInput/index.js
+++ b/src/modules/core/components/DateRangeInput/index.js
@@ -47,7 +47,11 @@ const DateRangeInput = ({ currentFilter = '', datastoreUid, filterGroupUid }) =>
     if (years.some((year) => {
       return year;
     })) {
-      filterValue = range === 'between' ? years.filter(Number).join(' to ') : `${range} ${years[0]}`;
+      if (range === 'between') {
+        filterValue = years.filter(Number).join(' to ');
+      } else {
+        filterValue = ['before', 'after'].includes(range) ? `${range} ${years[0]}` : years[0];
+      }
     }
     updateFilter(filterValue);
   }, [range, years, updateFilter]);

--- a/src/modules/core/components/DateRangeInput/index.js
+++ b/src/modules/core/components/DateRangeInput/index.js
@@ -1,35 +1,17 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { setAdvancedFilter } from '../../../advanced';
+import { useDispatch } from 'react-redux';
 
 const dateRangeOptions = ['before', 'after', 'between', 'in'];
 
-const DateRangeInput = ({ datastoreUid, filterGroupUid }) => {
+const DateRangeInput = ({ currentFilters, datastoreUid, filterGroupUid }) => {
   const dispatch = useDispatch();
   const [range, setRange] = useState(dateRangeOptions[0]);
   const [firstYear, setFirstYear] = useState('');
   const [secondYear, setSecondYear] = useState('');
-  const { [filterGroupUid]: urlFilters = [] } = useSelector((state) => {
-    return state.filters.active[datastoreUid] || {};
-  });
-  const { activeFilters = {} } = useSelector((state) => {
-    return state.advanced[datastoreUid] || {};
-  });
-  const advancedFilters = useMemo(() => {
-    return activeFilters[filterGroupUid] || [];
-  }, [activeFilters, filterGroupUid]);
 
   useEffect(() => {
-    // Make sure the URL filters and the advanced filters match on load
-    const currentFilters = [
-      ...urlFilters.filter((urlFilter) => {
-        return !advancedFilters.includes(urlFilter);
-      }),
-      ...advancedFilters.filter((advancedFilter) => {
-        return !urlFilters.includes(advancedFilter);
-      })
-    ];
     currentFilters.forEach((filterValue) => {
       dispatch(setAdvancedFilter({
         datastoreUid,
@@ -125,6 +107,7 @@ const DateRangeInput = ({ datastoreUid, filterGroupUid }) => {
 };
 
 DateRangeInput.propTypes = {
+  currentFilters: PropTypes.array,
   datastoreUid: PropTypes.string,
   filterGroupUid: PropTypes.string
 };

--- a/src/modules/core/components/Multiselect/index.js
+++ b/src/modules/core/components/Multiselect/index.js
@@ -12,8 +12,8 @@ const Multiselect = ({ datastoreUid, filterGroupUid, filters = {}, name }) => {
   const { [filterGroupUid]: urlFilters = [] } = useSelector((state) => {
     return state.filters.active[datastoreUid] || {};
   });
-  const { [filterGroupUid]: advancedFilters = [] } = useSelector((state) => {
-    return state.advanced[datastoreUid].activeFilters || {};
+  const { activeFilters = {} } = useSelector((state) => {
+    return state.advanced[datastoreUid] || {};
   });
 
   const options = useMemo(() => {
@@ -29,6 +29,9 @@ const Multiselect = ({ datastoreUid, filterGroupUid, filters = {}, name }) => {
   if (!options.length) {
     return null;
   }
+  const advancedFilters = useMemo(() => {
+    return activeFilters[filterGroupUid] || [];
+  }, [activeFilters, filterGroupUid]);
 
   useEffect(() => {
     // Make sure the URL filters and the advanced filters match on load

--- a/src/modules/core/components/Multiselect/index.js
+++ b/src/modules/core/components/Multiselect/index.js
@@ -1,20 +1,13 @@
 import './styles.css';
 import React, { useEffect, useMemo, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { setAdvancedFilter } from '../../../advanced';
+import { useDispatch } from 'react-redux';
 
-const Multiselect = ({ datastoreUid, filterGroupUid, filters = {}, name }) => {
+const Multiselect = ({ currentFilters, datastoreUid, filterGroupUid, filters = {}, name }) => {
   const dispatch = useDispatch();
   const [filterQuery, setFilterQuery] = useState('');
   const [showOnlySelectedOptions, setShowOnlySelectedOptions] = useState(false);
-
-  const { [filterGroupUid]: urlFilters = [] } = useSelector((state) => {
-    return state.filters.active[datastoreUid] || {};
-  });
-  const { activeFilters = {} } = useSelector((state) => {
-    return state.advanced[datastoreUid] || {};
-  });
 
   const options = useMemo(() => {
     return filters.map(({ isActive, value }) => {
@@ -29,20 +22,8 @@ const Multiselect = ({ datastoreUid, filterGroupUid, filters = {}, name }) => {
   if (!options.length) {
     return null;
   }
-  const advancedFilters = useMemo(() => {
-    return activeFilters[filterGroupUid] || [];
-  }, [activeFilters, filterGroupUid]);
 
   useEffect(() => {
-    // Make sure the URL filters and the advanced filters match on load
-    const currentFilters = [
-      ...urlFilters.filter((urlFilter) => {
-        return !advancedFilters.includes(urlFilter);
-      }),
-      ...advancedFilters.filter((advancedFilter) => {
-        return !urlFilters.includes(advancedFilter);
-      })
-    ];
     currentFilters.forEach((filterValue) => {
       dispatch(setAdvancedFilter({
         datastoreUid,
@@ -132,6 +113,7 @@ const Multiselect = ({ datastoreUid, filterGroupUid, filters = {}, name }) => {
 };
 
 Multiselect.propTypes = {
+  currentFilters: PropTypes.array,
   datastoreUid: PropTypes.string,
   filterGroupUid: PropTypes.string,
   filters: PropTypes.array,

--- a/src/modules/records/components/Pagination/styles.css
+++ b/src/modules/records/components/Pagination/styles.css
@@ -32,12 +32,9 @@
   justify-self: end;
 }
 .pagination-input {
-  border: solid 1px rgba(0, 0, 0, 0.3);
-  border-radius: 4px;
-  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.08);
   display: flex;
-  margin: 0 0.5rem;
-  padding: 0.15rem;
+  margin: 0 0.5rem!important;
+  padding: 0.15rem!important;
   text-align: center;
-  width: 5rem;
+  width: 5rem!important;
 }

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -1956,16 +1956,6 @@ body {
   padding-right: 0.5rem;
 }
 
-.date-range-input .switch-options {
-  justify-content: flex-start;
-}
-
-.date-range-container {
-  display: flex;
-  gap: 1rem;
-  margin-top: 0.5rem;
-}
-
 .chat-widget {
   position: fixed;
   right: 1.5%;

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -329,15 +329,17 @@ input[type="url"],
 input[type="search"],
 input[type="email"],
 input[type="tel"],
-input[type="date"] {
+input[type="date"],
+input[type="number"] {
+  background: white;
+  border: solid 1px var(--search-color-grey-400);
+  border-radius: 4px;
+  box-shadow: inset 0 1px 4px var(--search-color-grey-300);
+  font-size: 1rem;
+  line-height: 1.4;
   margin: 0;
   padding: 0;
-  font-size: 1rem;
-  border: solid 1px rgba(0, 0, 0, 0.3);
-  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.08);
-  border-radius: 4px;
   padding: 0.5rem 0.75rem;
-  line-height: 1.4;
   width: 100%;
 }
 
@@ -354,9 +356,11 @@ input[type="tel"]:read-only,
 input[type="text"]:disabled,
 input[type="text"]:read-only,
 input[type="url"]:disabled,
-input[type="url"]:read-only {
-  background: #FAFAFA;
-  border-color: #CCC;
+input[type="url"]:read-only,
+input[type="number"]:disabled,
+input[type="number"]:read-only {
+  background: var(--search-color-grey-200);
+  border-color: var(--search-color-grey-400);
   color: var(--search-color-grey-600);
   cursor: not-allowed;
 }


### PR DESCRIPTION
# Overview
This pull request focuses on making changes to the `DateRangeInput` component. Below are the noted changes:
- Separated `DateRangeInput` from `AdvancedFilter` for easier access and control.
- Updated `DateRangeInput` to use `number` input types instead of text.
- Added styles for `input[type="number"]`.
- Updated `Multiselect` with simpler logic, and to set advanced filters on load based on the current filters set by the URL.
- Moved logic for grabbing current and advanced filters into `FiltersContainer`  to resolve the `Selector unknown...` warning.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check advanced search and compare it to the current site.
  - Does it look and feel the same?
  - If there are filters set, do they carry throughout the datastore?
  - If you are given a direct link with filters applied to the URL, do those filters become active on load?
