### PR TITLE
[LIBSEARCH-1040] Remove Hotjar Tracking Code from U-M Library Search

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,25 +44,6 @@
       gtag('js', new Date());
       gtag('config', 'G-W0C2LGTEDC');
     </script>
-    <!-- Hotjar Tracking Code -->
-    <script>
-      (function (h, o, t, j, a, r) {
-        h.hj =
-          h.hj ||
-          function () {
-            (h.hj.q = h.hj.q || []).push(arguments);
-          };
-        h._hjSettings = {
-          hjid: 1553464,
-          hjsv: 6,
-        };
-        a = o.getElementsByTagName("head")[0];
-        r = o.createElement("script");
-        r.async = 1;
-        r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
-        a.appendChild(r);
-      })(window, document, "https://static.hotjar.com/c/hotjar-", ".js?sv=");
-    </script>
     <style>
       .site-skip-links:not(:focus-within) {
         position: absolute;


### PR DESCRIPTION
# Overview
The Hotjar license has been cancelled, and has been replaced by Microsoft Clarify. As a result, the Hotjar script needs to be removed as it's not longer being used.

This pull request closes [LIBSEARCH-1040](https://mlit.atlassian.net/browse/LIBSEARCH-1040).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Run the site and check if anything is broken.
