### PR TITLE
[LIBSEARCH-950] Add link to Citation assistance to Cite Action pane

### DIFF
--- a/src/modules/lists/components/CitationAction/index.js
+++ b/src/modules/lists/components/CitationAction/index.js
@@ -1,6 +1,6 @@
 import './styles.css';
+import { Anchor, Tab, TabPanel, Tabs } from '../../../reusable';
 import React, { useEffect, useState } from 'react';
-import { Tab, TabPanel, Tabs } from '../../../reusable';
 import { cite } from '../../../citations';
 import PropTypes from 'prop-types';
 
@@ -119,7 +119,18 @@ const CitationAction = ({ datastore, list, record, setActive, setAlert, viewType
                       className='font-small citation-disclaimer'
                       id={`${citationOption.id}-disclaimer`}
                     >
-                      These citations are generated from a variety of data sources. Remember to check citation format and content for accuracy before including them in your work.
+                      These citations are generated from a variety of data sources.
+                      Remember to check citation format and content for accuracy before including them in your work.
+                      View the
+                      {' '}
+                      <Anchor
+                        to='https://lib.umich.edu/research-and-scholarship/help-research/citation-management'
+                        target='_blank'
+                        rel='noopener noreferrer'
+                      >
+                        Citation Management guide on U-M Library Website (opens in new tab)
+                      </Anchor>
+                      .
                     </p>
                     <button
                       onClick={() => {


### PR DESCRIPTION
# Overview
This sentence with a link has been added to the Cite Action:

> View the [Citation Management guide on U-M Library Website (opens in new tab)](https://lib.umich.edu/research-and-scholarship/help-research/citation-management).

This pull request closes [LIBSEARCH-950](https://mlit.atlassian.net/browse/LIBSEARCH-950).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- View a record and check the `Citation` tab under `Actions`.
  - Do you see the new text in the description?
  - Does the link work?
