### PR TITLE
[LIBSEARCH-968] Articles results in Everything results view have no truncation on author data displayed

### DIFF
--- a/src/modules/records/components/RecommendedResource/index.js
+++ b/src/modules/records/components/RecommendedResource/index.js
@@ -1,16 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const RecommendedResource = ({ record }) => {
-  const isRecommended = record.fields.some((item) => {
-    return item.uid === 'highly_recommended';
+const RecommendedResource = ({ fields = [] }) => {
+  const isRecommended = fields.some(({ uid }) => {
+    return uid === 'highly_recommended';
   });
 
   return isRecommended ? <span className='recommended-resource-tag strong'>Recommended</span> : null;
 };
 
 RecommendedResource.propTypes = {
-  record: PropTypes.object
+  fields: PropTypes.array
 };
 
 export default RecommendedResource;

--- a/src/modules/records/components/Record/index.js
+++ b/src/modules/records/components/Record/index.js
@@ -62,7 +62,7 @@ const Header = ({ datastoreUid, record }) => {
           </span>
         );
       })}
-      <RecommendedResource {...{ record }} />
+      <RecommendedResource {...{ fields: record.fields }} />
     </h3>
   );
 };
@@ -84,8 +84,8 @@ const Record = ({ datastoreUid, list, record }) => {
           <Header {...{ datastoreUid, record }} />
           <AddToListButton item={record} />
         </div>
-        <Zotero {...{ record }} />
-        <RecordMetadata {...{ record }} />
+        <Zotero {...{ fields: record.fields }} />
+        <RecordMetadata {...{ metadata: record.metadata }} />
       </div>
 
       <div className='record-holders-container'>

--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -151,14 +151,14 @@ const FullRecord = () => {
                   <TrimString string={title} expandable key={index} />
                 );
               })}
-              <RecommendedResource record={record} />
+              <RecommendedResource fields={record.fields} />
             </H1>
             <AddToListButton item={record} />
           </div>
           <RecordDescription record={record} />
-          <Zotero record={record} />
+          <Zotero fields={record.fields} />
           <h2 className='full-record__record-info'>Record info:</h2>
-          <RecordMetadata record={record} />
+          <RecordMetadata metadata={record.metadata} />
           {inDatastore && (
             <p>
               The University of Michigan Library aims to describe its collections in a way that respects the people and communities who create, use, and are represented in them. We encourage you to

--- a/src/modules/records/components/RecordMetadata/index.js
+++ b/src/modules/records/components/RecordMetadata/index.js
@@ -2,29 +2,28 @@ import { ContextProvider, Metadata } from '../../../reusable';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const RecordMetadata = ({ record }) => {
-  const { metadata } = record;
-
-  if (!metadata) {
-    return null;
-  }
-
+const RecordMetadata = ({ metadata = {} }) => {
   return (
     <ContextProvider
-      render={(context) => {
+      render={({ viewType }) => {
+        if (!metadata || Object.keys(metadata).length === 0) {
+          return null;
+        }
+
         const data = {
           Full: metadata.full,
           Medium: metadata.medium,
           Preview: metadata.preview
         };
-        return <Metadata data={data[context.viewType] || metadata.full} viewType={context.viewType} />;
+
+        return <Metadata {...{ data: data[viewType] || metadata.full, viewType }} />;
       }}
     />
   );
 };
 
 RecordMetadata.propTypes = {
-  record: PropTypes.object
+  metadata: PropTypes.object
 };
 
 export default RecordMetadata;

--- a/src/modules/records/components/RecordMetadata/index.js
+++ b/src/modules/records/components/RecordMetadata/index.js
@@ -2,7 +2,7 @@ import { ContextProvider, Metadata } from '../../../reusable';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const RecordMetadata = ({ kind, record }) => {
+const RecordMetadata = ({ record }) => {
   const { metadata } = record;
 
   if (!metadata) {
@@ -17,14 +17,13 @@ const RecordMetadata = ({ kind, record }) => {
           Medium: metadata.medium,
           Preview: metadata.preview
         };
-        return <Metadata data={data[context.viewType] || metadata.full} kind={kind} />;
+        return <Metadata data={data[context.viewType] || metadata.full} viewType={context.viewType} />;
       }}
     />
   );
 };
 
 RecordMetadata.propTypes = {
-  kind: PropTypes.string,
   record: PropTypes.object
 };
 

--- a/src/modules/records/components/RecordPreview/index.js
+++ b/src/modules/records/components/RecordPreview/index.js
@@ -53,7 +53,7 @@ const Header = ({ datastoreUid, record, searchQuery }) => {
             </Anchor>
           );
         })}
-        <RecommendedResource record={record} />
+        <RecommendedResource fields={record.fields} />
       </h3>
     </>
   );
@@ -109,8 +109,8 @@ const RecordPreview = ({ datastoreUid, record, searchQuery }) => {
   return (
     <article className='record-preview'>
       <Header {...{ datastoreUid, record, searchQuery }} />
-      <RecordMetadata {...{ record }} />
-      <Zotero {...{ record }} />
+      <RecordMetadata {...{ metadata: record.metadata }} />
+      <Zotero {...{ fields: record.fields }} />
       <Footer {...{ record, searchQuery }} />
     </article>
   );

--- a/src/modules/records/components/RecordPreview/index.js
+++ b/src/modules/records/components/RecordPreview/index.js
@@ -109,7 +109,7 @@ const RecordPreview = ({ datastoreUid, record, searchQuery }) => {
   return (
     <article className='record-preview'>
       <Header {...{ datastoreUid, record, searchQuery }} />
-      <RecordMetadata {...{ record }} kind='condensed' />
+      <RecordMetadata {...{ record }} />
       <Zotero {...{ record }} />
       <Footer {...{ record, searchQuery }} />
     </article>

--- a/src/modules/records/components/Zotero/index.js
+++ b/src/modules/records/components/Zotero/index.js
@@ -20,9 +20,9 @@ import PropTypes from 'prop-types';
  *
  * And tell Zotero COinS was created.
  */
-const Zotero = ({ record }) => {
+const Zotero = ({ fields = [] }) => {
   const [z3988, setZ3988] = useState(null);
-  const [value] = getFieldValue(getField(record.fields, 'z3988'));
+  const [value] = getFieldValue(getField(fields, 'z3988'));
 
   useEffect(() => {
     setZ3988(value);
@@ -46,7 +46,7 @@ const Zotero = ({ record }) => {
 };
 
 Zotero.propTypes = {
-  record: PropTypes.object
+  fields: PropTypes.array
 };
 
 export default Zotero;

--- a/src/modules/reusable/components/Metadata/index.js
+++ b/src/modules/reusable/components/Metadata/index.js
@@ -10,6 +10,7 @@ import { BrowseLink } from '../../../browse';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { stringifySearch } from '../../../search';
+import { TrimString } from '../../../core';
 import { useSelector } from 'react-redux';
 
 const DescriptionItem = ({ browse, children, href, search }) => {
@@ -63,7 +64,7 @@ DescriptionItem.propTypes = {
   search: PropTypes.object
 };
 
-const Description = ({ data }) => {
+const Description = ({ data, viewType }) => {
   if (Array.isArray(data)) {
     return (
       <ol className='list__unstyled'>
@@ -79,7 +80,7 @@ const Description = ({ data }) => {
     );
   }
 
-  const { icon, image, text } = data;
+  const { icon, image, search: { scope } = {}, text } = data;
 
   return (
     <DescriptionItem {...data}>
@@ -91,7 +92,7 @@ const Description = ({ data }) => {
             className='margin-right__2xs text-grey__light'
           />
         )}
-        {text}
+        {scope === 'author' && viewType !== 'Full' ? <TrimString {...{ string: text, trimLength: 64 }} /> : text}
       </span>
       {image && (
         <img
@@ -108,26 +109,27 @@ Description.propTypes = {
   data: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.object
-  ])
+  ]),
+  viewType: PropTypes.string
 };
 
-export default function Metadata ({ data, kind }) {
+export default function Metadata ({ data, viewType }) {
   return (
     <dl className='flex__responsive metadata-list'>
       {data.map((datum, datumIndex) => {
         const { description, term, termPlural } = datum;
         const isExpandable = description.length > 5;
         return (
-          <div className={kind === 'condensed' ? '' : 'metadata-list-item'} key={datumIndex}>
+          <div className={viewType === 'Preview' ? '' : 'metadata-list-item'} key={datumIndex}>
             <Expandable>
-              <dt className={kind === 'condensed' ? 'visually-hidden' : ''}>
+              <dt className={viewType === 'Preview' ? 'visually-hidden' : ''}>
                 {term}
               </dt>
               <ExpandableChildren show={isExpandable ? 4 : description.length}>
                 {description.map((descriptor, index) => {
                   return (
                     <dd key={index}>
-                      <Description data={descriptor} />
+                      <Description data={descriptor} viewType={viewType} />
                     </dd>
                   );
                 })}
@@ -143,5 +145,5 @@ export default function Metadata ({ data, kind }) {
 
 Metadata.propTypes = {
   data: PropTypes.array,
-  kind: PropTypes.string
+  viewType: PropTypes.string
 };


### PR DESCRIPTION
# Overview
The length of authors does not have a limit. This can be problematic when seeing [results with many authors](https://search.lib.umich.edu/everything?query=HIV+Prevalence+Incidence+Mortality+Trends+US). This pull request specifically looks for `author` in `Medium` or `Preview` record views and uses the `TrimString` component.

This pull request fixes [LIBSEARCH-968](https://mlit.atlassian.net/browse/LIBSEARCH-968).

## Anything else?
Multiple components were pulling in the entire `record` object, when they only needed one property from it. They have been updated to only pull in the necessary information.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Search [a query with a lengthy amount of authors](http://localhost:3000/everything?query=HIV+Prevalence+Incidence+Mortality+Trends+US).
  - Do they get truncated with ellipses?
  - Do you see the full list when in full view?
  - Does the rest of the site still work?
