### PR TITLE
Invert the logic on whether it's a top-level

### DIFF
--- a/src/modules/browse/organizeByParents.js
+++ b/src/modules/browse/organizeByParents.js
@@ -16,8 +16,8 @@ const organizeByParents = (array) => {
 
   return array
     .filter((item) => {
-      return !item.parents.length || item.parents.some((parent) => {
-        return !parentMap.has(parent);
+      return !item.parents.length || !item.parents.some((parent) => {
+        return parentMap.has(parent);
       });
     })
     .map((item) => {


### PR DESCRIPTION
If it lists parents, but none are found, then it's a top level parent.

This change prevents a middle level showing up as a top level, too if one parent isn't found.

There's no UI changes other than how some terms are organized.