### PR TITLE
Bug: Individual `Summary` entries get trimmed, instead of full collection.

### DIFF
--- a/src/modules/records/components/Metadata/index.js
+++ b/src/modules/records/components/Metadata/index.js
@@ -54,7 +54,7 @@ const Metadata = ({ metadata = {} }) => {
                         );
                       })}
                     </ExpandableChildren>
-                    {(term !== 'Summary' && description.length > 3) && <dd className='margin-top__2xs'><ExpandableButton name={termPlural || term} count={description.length} /></dd>}
+                    {description.length > 3 && <dd className='margin-top__2xs'><ExpandableButton name={termPlural || term} count={description.length} /></dd>}
                   </Expandable>
                 </div>
               );

--- a/src/modules/records/components/Metadata/index.js
+++ b/src/modules/records/components/Metadata/index.js
@@ -45,7 +45,7 @@ const Metadata = ({ metadata = {} }) => {
                     <dt className={viewType === 'Preview' ? 'visually-hidden' : ''}>
                       {term}
                     </dt>
-                    <ExpandableChildren>
+                    <ExpandableChildren show={term === 'Summary' && viewType !== 'Full' ? 1 : 3}>
                       {description.map((data, dataIndex) => {
                         return (
                           <dd key={dataIndex}>
@@ -54,7 +54,7 @@ const Metadata = ({ metadata = {} }) => {
                         );
                       })}
                     </ExpandableChildren>
-                    {description.length > 3 && <dd className='margin-top__2xs'><ExpandableButton name={termPlural || term} count={description.length} /></dd>}
+                    {(term !== 'Summary' && description.length > 3) && <dd className='margin-top__2xs'><ExpandableButton name={termPlural || term} count={description.length} /></dd>}
                   </Expandable>
                 </div>
               );


### PR DESCRIPTION
# Overview
When viewing a `Preview` or `Medium` record, by default, each individual piece of `metadata` gets trimmed if the length of text goes beyond 240 characters. If a record has [multiple summaries](https://search-staging.www.lib.umich.edu/catalog?query=MUMBO+JUMBO+GUMBO+WORKS%3A+THE+KALEIDOSCOPIC+FICTION+OF+ISHMAEL+REED+.%E2%81%A9), each individual summary gets trimmed and displayed instead of being viewed as a whole block of text.

To resolve this, the `metadata` only shows the first summary if not viewing a `Full` record, which gets trimmed if necessary.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check a record with [multiple summaries](http://localhost:3000/catalog?query=MUMBO+JUMBO+GUMBO+WORKS%3A+THE+KALEIDOSCOPIC+FICTION+OF+ISHMAEL+REED+.%E2%81%A9).
  - Do you only see the first summary?
  - Do you see the remaining summaries when you view the full record?
