### PR TITLE
Bug: Full ROnline Journals records do not display from lack of `indexing_date`.

### DIFF
--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -123,6 +123,8 @@ const FullRecord = () => {
 
   const inDatastore = ['catalog', 'onlinejournals'].includes(datastoreSlug);
 
+  const { name: indexingName, value: indexingValue } = findWhere(record.fields, { uid: 'indexing_date' }) || {};
+
   return (
     <div className='container container-narrow full-record-page-container y-spacing'>
       <Breadcrumb
@@ -200,17 +202,11 @@ const FullRecord = () => {
         }}
         />
       </div>
-      {inDatastore && (() => {
-        const { name: indexingName, value: indexingValue } = findWhere(record.fields, { uid: 'indexing_date' });
-        if (!indexingValue) {
-          return null;
-        }
-        return (
-          <p className='margin-top__none text-grey full-record__date-last-indexed'>
-            <span className='strong'>{indexingName || 'Date Last Indexed'}:</span> {indexingValue}
-          </p>
-        );
-      })()}
+      {indexingValue && (
+        <p className='margin-top__none text-grey full-record__date-last-indexed'>
+          <span className='strong'>{indexingName || 'Date Last Indexed'}:</span> {indexingValue}
+        </p>
+      )}
       {datastoreUid === 'mirlyn' && <ViewMARC {...{ fields: record.fields }} />}
     </div>
   );


### PR DESCRIPTION
# Overview
Viewing a [full Online Journal record](https://search.lib.umich.edu/onlinejournals/record/99187579295006381) does not display because of this error:

```
Uncaught TypeError: Cannot destructure property 'name' of 'At(...)' as it is undefined.
    at index.js:204:23
    at da (index.js:203:23)
```

This was because `findWhere(record.fields, { uid: 'indexing_date' })` would return `undefined`. An empty object has been added as a backup.

## Anything else?
The `inDatastore` check has been removed. It will now display on any record where the field exists.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check a [full Online Journal record](http://localhost:3000/onlinejournals/record/99187579295006381)  and see if you can view it.
  - Check any other record to see if they still display.
