### PR TITLE
[LIBSEARCH-1052] Change position of Abstract in Articles medium view results

### DIFF
--- a/src/modules/records/components/Record/index.js
+++ b/src/modules/records/components/Record/index.js
@@ -70,6 +70,7 @@ const Record = ({ datastoreUid, list, record }) => {
   if (!getField(record.fields, 'id')) {
     return null;
   }
+  const [description] = getFieldValue(getField(record.fields, 'abstract'));
 
   return (
     <article className={`container__rounded record ${(isInList(list, record.uid) ? ' record--highlight' : '')}`}>
@@ -78,6 +79,7 @@ const Record = ({ datastoreUid, list, record }) => {
           <Header {...{ datastoreUid, record }} />
           <AddToListButton item={record} />
         </div>
+        {description && <p className='margin-top__2xs'><TrimString string={description} /></p>}
         <Zotero {...{ fields: record.fields }} />
         <Metadata {...{ metadata: record.metadata }} />
       </div>


### PR DESCRIPTION
# Overview
For Article records, the full record displays the `abstract` field below the `title`. In the medium view, the `abstract` field is in the `metadata` list. This pull request moves the trimmed `abstract` field underneath the record's `title` on medium views to reflect the full record's structure.

This pull request fixes [LIBSEARCH-1052](https://mlit.atlassian.net/browse/LIBSEARCH-1052).

## Anything else?
[Spectrum](https://github.com/mlibrary/spectrum/blob/main/config/fields.yml#L869) needs to be updated to remove the field from the view.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check out list of articles results.
  - Do you see the abstract underneath the title in medium views?
  - Do you still not see it in preview views?
  - Do you still see it in full record?
