### PR TITLE
[LIBSEARCH-1081] Add "View MARC data" button to Online Journal records (bring into alignment with Catalog)

### DIFF
--- a/src/modules/records/components/RecordFull/index.js
+++ b/src/modules/records/components/RecordFull/index.js
@@ -207,7 +207,7 @@ const FullRecord = () => {
           <span className='strong'>{indexingName || 'Date Last Indexed'}:</span> {indexingValue}
         </p>
       )}
-      {datastoreUid === 'mirlyn' && <ViewMARC {...{ fields: record.fields }} />}
+      <ViewMARC {...{ fields: record.fields }} />
     </div>
   );
 };


### PR DESCRIPTION
# Overview

> **Problem Statement**
> 
> We do not shown the "View MARC data" link on records in the Online Journals portion of Library Search; that is only available in Catalog. The reason originally was, pre-Alma, that Online Journals was searching and displaying a limited set of metadata that was extracted from Aleph. As part of the migration to Alma, we changed Online Journals to be a subset of catalog data, rather than a specially-created separate, limited, index. Online Journals records are basically otherwise identical to Catalog Records in most respects.
> 
> **Success Criteria**
> 
> Add the “View MARC data” button that currently appears beneath holdings in Catalog records in the same position on Online Journals records.

Showing the `ViewMARC` component was controlled by making sure the current datastore is `mirlyn`. The datastore check has been removed since `ViewMARC` will simply return `null` if the data does not exist, no matter what datastore the record is in.

This pull request closes [LIBSEARCH-1081](https://mlit.atlassian.net/browse/LIBSEARCH-1081).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check an Online Journal record and see if the `View MARC data` button appears.
  - Check other full records to see if it does or does not appear, when it appropriately should or should not.
