### PR TITLE
[LIBSEARCH-1091] Change link to citation help

### DIFF
--- a/src/modules/lists/components/CitationAction/index.js
+++ b/src/modules/lists/components/CitationAction/index.js
@@ -145,7 +145,7 @@ const CitationAction = ({ list = [], record = {}, setActive, setAlert, viewType 
                 These citations are generated from a variety of data sources. Remember to check citation format and content for accuracy before including them in your work. View the
                 {' '}
                 <Anchor
-                  to='https://lib.umich.edu/research-and-scholarship/help-research/citation-management'
+                  to='https://guides.lib.umich.edu/citationhelp'
                   target='_blank'
                   rel='noopener noreferrer'
                 >


### PR DESCRIPTION
# Overview
> Update the link displayed in the Actions bar to https://guides.lib.umich.edu/citationhelp 

This pull request resolves  [LIBSEARCH-1091](https://mlit.atlassian.net/browse/LIBSEARCH-1091).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check a full record, and open the `Citations` tab in the `Actions` bar. Does the link go to https://guides.lib.umich.edu/citationhelp?
