### PR TITLE
[LIBSEARCH-1097] Change "cancel" date in Get This Request for Pickup in a Library to be no sooner than 2 weeks away

### DIFF
--- a/src/modules/getthis/components/GetThisForm/index.js
+++ b/src/modules/getthis/components/GetThisForm/index.js
@@ -5,7 +5,7 @@ import { Pride } from 'pride';
 import { useSelector } from 'react-redux';
 
 const Field = ({ field, loading, setFieldChange }) => {
-  const { name, options, type, value } = field;
+  const { name, options = [], type, value } = field;
 
   if (type === 'hidden') {
     return <input id={name} type={type} name={name} value={value} onChange={setFieldChange} />;
@@ -48,10 +48,28 @@ const Field = ({ field, loading, setFieldChange }) => {
     );
   }
 
+  const attributes = {
+    className: 'form-controls',
+    id: name,
+    name,
+    onChange: setFieldChange,
+    type,
+    value
+  };
+
+  if (type === 'date') {
+    const date = new Date();
+    // Set date two weeks from today
+    date.setDate(date.getDate() + 14);
+    // Get date string `YYYY-MM-DD`
+    const [formattedDate] = date.toISOString().split('T');
+    attributes.min = formattedDate;
+  }
+
   return (
     <div className='form-group'>
       {field.label && <label className='form-label' htmlFor={field.name}>{field.label}</label>}
-      <input className='form-control' id={name} type={type} name={name} value={value} onChange={setFieldChange} />
+      <input {...attributes} />
     </div>
   );
 };
@@ -129,8 +147,6 @@ const GetThisForm = ({ form }) => {
     );
   };
 
-  const showForm = !response || response.status !== 'Action Succeeded';
-
   if (!form) {
     return (
       <Alert type='warning'>
@@ -142,7 +158,7 @@ const GetThisForm = ({ form }) => {
   return (
     <>
       {renderResponse()}
-      {showForm && (
+      {(!response || response.status !== 'Action Succeeded') && (
         <form action={form.action} method={form.method} onSubmit={handleSubmit}>
           {fields.map((field, index) => {
             return (


### PR DESCRIPTION
# Overview
When a patron chooses the "Request for pickup at the library" option in Get This, they get the option to choose where they would like it picked up, along with a "Cancel this hold if item is not available before" date selector. This pull request updates the form that sets a `min` attribute to be two weeks after the current date, disabling the ability for a patron to choose the next day.

This pull request resolves [LIBSEARCH-1097](https://mlit.atlassian.net/browse/LIBSEARCH-1097).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Click on a `Get This` link for a catalog record. Log in and select the `Request for pick up at a library` accordion. Change the date in the "Cancel this hold if item is not available before" input. Can you select the date earlier than two weeks from today?
