### PR TITLE
[LIBSEARCH-1094] "Talk to a Library Specialist" results do not appear in Everything results until after another datastore is selected

### DIFF
--- a/src/modules/pride/setup.js
+++ b/src/modules/pride/setup.js
@@ -51,10 +51,9 @@ const handleSearchData = (data, datastoreUid) => {
     total_available: totalAvailable,
     total_pages: totalPages
   } = data;
-  const { datastores, records } = store.getState();
-  const { active: activeDatastore } = datastores;
+  const { records } = store.getState();
 
-  if (['everything', activeDatastore].includes(datastoreUid) && specialists) {
+  if (data.specialists) {
     store.dispatch(addSpecialists(specialists));
   }
 


### PR DESCRIPTION
# Overview
When first loading results on the Everything datastore, `state.specialists` returns an empty array. This changes when you switch to another datastore and go back to Everything. The check for the current datastore has been removed, and will add specialists to the `state` by default, based on the data.

This pull request fixes [LIBSEARCH-1094](https://mlit.atlassian.net/browse/LIBSEARCH-1094).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Load Search and submit a search. Does the specialists panel appear?
