### PR TITLE
[LIBSEARCH-1170] Make floor location in catalog holdings visible again

### DIFF
--- a/src/modules/resource-acccess/components/Holder/index.js
+++ b/src/modules/resource-acccess/components/Holder/index.js
@@ -13,26 +13,10 @@ const notesList = (notes) => {
     return null;
   }
 
-  if (notes.length === 1) {
-    return (
-      <Expandable>
-        <ExpandableChildren show={0}>
-          <p className='text-grey__light margin-bottom__none'>
-            {notes[0]}
-          </p>
-        </ExpandableChildren>
-        <ExpandableButton
-          name='holdings note'
-          count={notes.length}
-        />
-      </Expandable>
-    );
-  }
-
   return (
     <Expandable>
       <ul className='margin-bottom__none'>
-        <ExpandableChildren show={0}>
+        <ExpandableChildren show={1}>
           {notes.map((note, index) => {
             return (
               <li
@@ -46,7 +30,7 @@ const notesList = (notes) => {
         </ExpandableChildren>
       </ul>
 
-      {notes.length > 0 && (
+      {notes.length > 1 && (
         <ExpandableButton
           name='holdings notes'
           count={notes.length}

--- a/src/modules/resource-acccess/components/Holder/styles.css
+++ b/src/modules/resource-acccess/components/Holder/styles.css
@@ -3,7 +3,6 @@
 }
 
 .holder-content > ul + .btn {
-  margin-left: 2.5rem;
   margin-top: 0;
 }
 


### PR DESCRIPTION
# Overview
The first note in holdings must now become visible as [Spectrum is updated to show the floor location in the first note](https://github.com/mlibrary/spectrum/pull/303).

This pull request fixes [LIBSEARCH-1170](https://mlit.atlassian.net/browse/LIBSEARCH-1170).

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check out the [holdings of a record](http://localhost:3000/catalog/record/990005465670106381). Does the expandable button appear when there is more than one note?
