### PR TITLE
Use git SHA for ALL GitHub actions by Wednesday, April 15

### DIFF
--- a/.github/workflows/build-deploy-on-release.yaml
+++ b/.github/workflows/build-deploy-on-release.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-production:
     name: Build production ${{ github.event.release.tag_name }}
-    uses: mlibrary/platform-engineering-workflows/.github/workflows/build-production.yml@v1
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/build-production.yml@2012bb6a322ad02c45c01372de2f5e2e3d7329ac # v1.6.7
     with:
       image_name: ${{ vars.IMAGE_NAME }}
       tag: ${{ github.event.release.tag_name }}
@@ -18,7 +18,7 @@ jobs:
   deploy-production:
     needs: build-production
     name: Deploy to production
-    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@2012bb6a322ad02c45c01372de2f5e2e3d7329ac # v1.6.7
     with:
       image: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.release.tag_name }}
       file: ${{ vars.CONFIG_REPO_PRODUCTION_IMAGE_FILE }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install latest LTS version of Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -26,7 +26,7 @@ jobs:
       - name: "Package: Staging"
         run: tar -C build --transform s/./search/ -czf search-staging.tar.gz .
       - name: "Upload Release Asset: Staging"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -43,7 +43,7 @@ jobs:
       - name: "Package: Production"
         run: tar -C build --transform s/./search/ -czf search-production.tar.gz .
       - name: "Upload Release Asset: Production"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -60,7 +60,7 @@ jobs:
       - name: "Package: Local"
         run: tar -C build --transform s/./search/ -czf search-local.tar.gz .
       - name: "Upload Release Asset: Local"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -75,7 +75,7 @@ jobs:
       - name: "Package: Origin"
         run: tar -C build --transform s/./search/ -czf search-origin.tar.gz .
       - name: "Upload Release Asset: Origin"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-unstable:
     name: Build unstable ${{ github.sha }}
-    uses: mlibrary/platform-engineering-workflows/.github/workflows/build-unstable.yml@v1
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/build-unstable.yml@2012bb6a322ad02c45c01372de2f5e2e3d7329ac # v1.6.7
     with:
       image_name: ${{ vars.IMAGE_NAME }}
       tag: ${{ github.sha }}
@@ -18,7 +18,7 @@ jobs:
   deploy-testing:
     needs: build-unstable
     name: Deploy to testing
-    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@2012bb6a322ad02c45c01372de2f5e2e3d7329ac # v1.6.7
     with:
       image: ${{ needs.build-unstable.outputs.image }}
       file: ${{ vars.CONFIG_REPO_TESTING_IMAGE_FILE }}

--- a/.github/workflows/dockerhub-release.yaml
+++ b/.github/workflows/dockerhub-release.yaml
@@ -8,27 +8,27 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Get the version
       id: tag
       run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Login to DockerHub
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and push
       id: docker_build
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         push: true
         tags: bertrama/search:${{ steps.tag.outputs.TAG }}

--- a/.github/workflows/dockerhub-unstable.yaml
+++ b/.github/workflows/dockerhub-unstable.yaml
@@ -8,13 +8,13 @@ jobs:
     if: ${{github.actor != 'dependabot[bot]'}}
     steps:
     - name: Login to DockerHub
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build container image and push to DockerHub
       id: docker_build
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         push: true
         tags: 'bertrama/search-unstable:${{ github.sha }},bertrama/search-unstable:latest'

--- a/.github/workflows/manual-deploy-production.yml
+++ b/.github/workflows/manual-deploy-production.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-production:
     name: Build production ${{ github.event.inputs.tag }}
-    uses: mlibrary/platform-engineering-workflows/.github/workflows/build-production.yml@v1
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/build-production.yml@2012bb6a322ad02c45c01372de2f5e2e3d7329ac # v1.6.7
     with:
       image_name: ${{ vars.IMAGE_NAME }}
       tag: ${{ github.event.inputs.tag }}
@@ -21,7 +21,7 @@ jobs:
   deploy-production:
     needs: build-production
     name: Deploy to production
-    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@2012bb6a322ad02c45c01372de2f5e2e3d7329ac # v1.6.7
     with:
       image: ghcr.io/mlibrary/${{ vars.IMAGE_NAME }}:${{ github.event.inputs.tag }}
       file: ${{ vars.CONFIG_REPO_PRODUCTION_IMAGE_FILE }}

--- a/.github/workflows/manual-deploy-testing.yml
+++ b/.github/workflows/manual-deploy-testing.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-unstable:
     name: Build unstable ${{ github.event.inputs.tag }}
-    uses: mlibrary/platform-engineering-workflows/.github/workflows/build-unstable.yml@v1
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/build-unstable.yml@2012bb6a322ad02c45c01372de2f5e2e3d7329ac # v1.6.7
     with:
       image_name: ${{ vars.IMAGE_NAME }}
       tag: ${{ github.event.inputs.tag }}
@@ -20,7 +20,7 @@ jobs:
   deploy:
     needs: build-unstable
     name: Deploy to ${{ github.event.inputs.tanka_env }}
-    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@v1
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/deploy.yml@2012bb6a322ad02c45c01372de2f5e2e3d7329ac # v1.6.7
     with:
       image: ${{ needs.build-unstable.outputs.image }}
       file: ${{ vars.CONFIG_REPO_TESTING_IMAGE_FILE }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Install latest LTS version of Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: lts/*
           check-latest: true

--- a/.github/workflows/update-csl.yml
+++ b/.github/workflows/update-csl.yml
@@ -10,9 +10,9 @@ jobs:
       - name: Construct the target branch name
         id: date
         run: echo "::set-output name=branch::$(date +'%Y-%m-%d-update-csl-files')"
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: "npm run update:csl"
-      - uses: gr2m/create-or-update-pull-request-action@v1
+      - uses: gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b # v1.10.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
* _Action required:_ we will configure GitHub to prevent any actions from running if the SHA isn't use on Wednesday, April 15
* All actions used in your GitHub workflows should be updated to use the full SHA. We recommend also adding a human readable version tag in a comment. Dependabot will update both the SHA and the comment as long as the full version tag is used, and it matches the SHA.
* See example: [sample workflow yaml](https://github.com/mlibrary/gha-sandbox/blob/main/.github/workflows/demo.yaml) | [dependabot PR updating this file](https://github.com/mlibrary/gha-sandbox/pull/4/changes)
  * Note: comment tags must match release tag exactly (e.g. v6.3.0, not v6) in order for dependabot to maintain them for you